### PR TITLE
Add hazardous waste schema and validation tests

### DIFF
--- a/src/schemas/waste.js
+++ b/src/schemas/waste.js
@@ -18,6 +18,14 @@ const popsSchema = Joi.object({
 }).label('Pops')
 
 const hazardousSchema = Joi.object({
+  containsHazardous: Joi.boolean()
+    .required()
+    .messages({
+      'any.required':
+        'Hazardous waste is any waste that is potentially harmful to human health or the environment.'
+    })
+    .label('ContainsHazardous'),
+  hazCodes: Joi.array().items(Joi.number()).label('HazCodeItem'),
   components: Joi.array().items(
     Joi.object({
       name: Joi.string(),

--- a/src/schemas/waste.test.js
+++ b/src/schemas/waste.test.js
@@ -66,6 +66,107 @@ describe('Receipt Schema Validation', () => {
     })
   })
 
+  describe('Hazardous Waste Validation', () => {
+    // Helper function to validate a payload with hazardous waste data
+    const validateHazardous = (hazardous) => {
+      const payload = {
+        receivingSiteId: 'site123',
+        waste: [
+          {
+            ewcCodes: ['010101'],
+            wasteDescription: 'Test waste',
+            form: 'Solid',
+            hazardous: hazardous,
+            quantity: {
+              metric: 'Tonnes',
+              amount: 1,
+              isEstimate: false
+            }
+          }
+        ]
+      }
+
+      return receiveMovementRequestSchema.validate(payload)
+    }
+
+    it('should accept valid hazardous indicator (true)', () => {
+      const result = validateHazardous({
+        containsHazardous: true
+      })
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept valid hazardous indicator (false)', () => {
+      const result = validateHazardous({
+        containsHazardous: false
+      })
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept hazardous with hazCodes array', () => {
+      const result = validateHazardous({
+        containsHazardous: true,
+        hazCodes: [1, 2, 3]
+      })
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept hazardous with components array', () => {
+      const result = validateHazardous({
+        containsHazardous: true,
+        components: [
+          {
+            name: 'Mercury',
+            concentration: 30
+          },
+          {
+            name: 'Lead',
+            concentration: 15
+          }
+        ]
+      })
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept hazardous with both hazCodes and components', () => {
+      const result = validateHazardous({
+        containsHazardous: true,
+        hazCodes: [1, 2],
+        components: [
+          {
+            name: 'Mercury',
+            concentration: 30
+          }
+        ]
+      })
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept missing hazardous section', () => {
+      const result = validateHazardous(undefined)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should reject missing containsHazardous field when hazardous object exists', () => {
+      const result = validateHazardous({
+        hazCodes: [1, 2, 3]
+      })
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain(
+        'Hazardous waste is any waste that is potentially harmful to human health or the environment.'
+      )
+    })
+
+    it('should reject invalid hazCodes types', () => {
+      const result = validateHazardous({
+        containsHazardous: true,
+        hazCodes: ['not', 'numbers']
+      })
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain('must be a number')
+    })
+  })
+
   describe('EWC Code Validation', () => {
     // Helper function to validate a payload with a specific EWC code
     const validateEwcCode = (ewcCodeArray) => {


### PR DESCRIPTION
Introduced `containsHazardous` and `hazCodes` fields in the hazardous waste schema to enhance waste classification. Added comprehensive unit tests to validate hazardous waste scenarios, ensuring robustness and proper error handling for invalid inputs.