### PR TITLE
DWT-339 Site Waste Authorisation number [Array] 

### DIFF
--- a/src/schemas/receipt.js
+++ b/src/schemas/receipt.js
@@ -107,7 +107,7 @@ const receiverSchema = Joi.object({
   organisationName: Joi.string().required(),
   emailAddress: Joi.string().email(),
   phoneNumber: Joi.string(),
-  authorisationNumbers: Joi.array().items(Joi.string()),
+  authorisationNumbers: Joi.array().items(Joi.string()).min(1).required(),
   regulatoryPositionStatements: Joi.array().items(
     Joi.number().integer().positive()
   )

--- a/src/schemas/receiver.test.js
+++ b/src/schemas/receiver.test.js
@@ -12,7 +12,8 @@ describe('Receiver Validation', () => {
     const receiver = {
       organisationName: 'Test Receiver',
       emailAddress: 'receiver@example.com',
-      phoneNumber: '01234567890'
+      phoneNumber: '01234567890',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {
@@ -28,7 +29,8 @@ describe('Receiver Validation', () => {
 
   it('accepts when no receiver tel/email are provided', () => {
     const receiver = {
-      organisationName: 'Test Receiver'
+      organisationName: 'Test Receiver',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {
@@ -76,7 +78,7 @@ describe('Receiver Validation', () => {
     expect(error).toBeUndefined()
   })
 
-  it('accepts when no authorisation numbers are provided', () => {
+  it('rejects when no authorisation numbers are provided', () => {
     const receiver = {
       organisationName: 'Test Receiver'
     }
@@ -89,10 +91,11 @@ describe('Receiver Validation', () => {
     }
 
     const { error } = validate(receiver, receipt)
-    expect(error).toBeUndefined()
+    expect(error).toBeDefined()
+    expect(error.message).toBe('"receiver.authorisationNumbers" is required')
   })
 
-  it('accepts when authorisation numbers is an empty array', () => {
+  it('rejects when authorisation numbers is an empty array', () => {
     const receiver = {
       organisationName: 'Test Receiver',
       authorisationNumbers: []
@@ -106,7 +109,10 @@ describe('Receiver Validation', () => {
     }
 
     const { error } = validate(receiver, receipt)
-    expect(error).toBeUndefined()
+    expect(error).toBeDefined()
+    expect(error.message).toBe(
+      '"receiver.authorisationNumbers" must contain at least 1 items'
+    )
   })
 
   it('rejects when any receiver properties provided but organisationName missing', () => {
@@ -130,7 +136,8 @@ describe('Receiver Validation', () => {
     const receiver = {
       organisationName: 'Test Receiver',
       emailAddress: 'receiver@example.com',
-      phoneNumber: '01234567890'
+      phoneNumber: '01234567890',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {}
@@ -142,7 +149,8 @@ describe('Receiver Validation', () => {
 
   it('rejects incomplete receiver address without postcode', () => {
     const receiver = {
-      organisationName: 'Test Receiver'
+      organisationName: 'Test Receiver',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {
@@ -156,7 +164,8 @@ describe('Receiver Validation', () => {
 
   it('rejects incomplete receiver address without fullAddress', () => {
     const receiver = {
-      organisationName: 'Test Receiver'
+      organisationName: 'Test Receiver',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {
@@ -170,7 +179,8 @@ describe('Receiver Validation', () => {
 
   it('rejects invalid UK postcode', () => {
     const receiver = {
-      organisationName: 'Invalid Postcode Receiver'
+      organisationName: 'Invalid Postcode Receiver',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {
@@ -187,7 +197,8 @@ describe('Receiver Validation', () => {
 
   it('rejects valid Ireland Eircode', () => {
     const receiver = {
-      organisationName: 'Invalid Eircode Receiver'
+      organisationName: 'Invalid Eircode Receiver',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {
@@ -205,7 +216,8 @@ describe('Receiver Validation', () => {
   it('rejects invalid receiver email address', () => {
     const receiver = {
       organisationName: 'Invalid Email Receiver',
-      emailAddress: 'not-an-email'
+      emailAddress: 'not-an-email',
+      authorisationNumbers: ['EPR123']
     }
 
     const receipt = {
@@ -274,6 +286,7 @@ describe('Receiver Validation', () => {
   it('accepts receiver with only regulatory position statements', () => {
     const receiver = {
       organisationName: 'Test Receiver',
+      authorisationNumbers: ['EPR123'],
       regulatoryPositionStatements: [123, 456, 789]
     }
 

--- a/src/schemas/rps.test.js
+++ b/src/schemas/rps.test.js
@@ -57,7 +57,7 @@ describe('Regulatory Position Statement (RPS) Validation', () => {
       expect(error).toBeUndefined()
     })
 
-    it('accepts when both authorisations and RPS are empty', () => {
+    it('rejects when both authorisations and RPS are empty', () => {
       const receiver = {
         organisationName: 'Test Receiver',
         authorisationNumbers: [],
@@ -69,10 +69,13 @@ describe('Regulatory Position Statement (RPS) Validation', () => {
       }
 
       const { error } = validate(receiver, receipt)
-      expect(error).toBeUndefined()
+      expect(error).toBeDefined()
+      expect(error.message).toBe(
+        '"receiver.authorisationNumbers" must contain at least 1 items'
+      )
     })
 
-    it('accepts when neither authorisations nor RPS are provided', () => {
+    it('rejects when neither authorisations nor RPS are provided', () => {
       const receiver = {
         organisationName: 'Test Receiver'
       }
@@ -82,7 +85,8 @@ describe('Regulatory Position Statement (RPS) Validation', () => {
       }
 
       const { error } = validate(receiver, receipt)
-      expect(error).toBeUndefined()
+      expect(error).toBeDefined()
+      expect(error.message).toBe('"receiver.authorisationNumbers" is required')
     })
   })
 
@@ -185,7 +189,7 @@ describe('Regulatory Position Statement (RPS) Validation', () => {
   })
 
   describe('RPS can be provided independently of authorisation numbers', () => {
-    it('accepts RPS without any authorisation numbers', () => {
+    it('rejects RPS without any authorisation numbers', () => {
       const receiver = {
         organisationName: 'Test Receiver',
         regulatoryPositionStatements: [123, 456]
@@ -196,7 +200,8 @@ describe('Regulatory Position Statement (RPS) Validation', () => {
       }
 
       const { error } = validate(receiver, receipt)
-      expect(error).toBeUndefined()
+      expect(error).toBeDefined()
+      expect(error.message).toBe('"receiver.authorisationNumbers" is required')
     })
 
     it('accepts authorisation numbers without RPS', () => {


### PR DESCRIPTION
### Description
Ticket [DWT-339](https://eaflood.atlassian.net/browse/DWT-339)

- Updated the receipt schema to require at least one authorisation number in the `authorisationNumbers` field.  
- Adjusted and validated unit tests to ensure schema validation fails when `authorisationNumbers` is missing or empty.  

[DWT-339]: https://eaflood.atlassian.net/browse/DWT-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ