### PR TITLE
DWT-624 Update Hazardous components validation

### DIFF
--- a/src/common/helpers/validation-warnings.js
+++ b/src/common/helpers/validation-warnings.js
@@ -217,7 +217,7 @@ export const generatePopAndHazardousComponentWarnings = (
   }
 
   const warnings = []
-  const popsOrHazardousbjectProperty = String(popsOrHazardous).toLowerCase()
+  const popsOrHazardousObjectProperty = String(popsOrHazardous).toLowerCase()
   const containsPopsOrHazardousField = `contains${String(popsOrHazardous).charAt(0).toUpperCase()}${String(popsOrHazardous).toLowerCase().slice(1)}`
 
   if (!Array.isArray(payload?.wasteItems)) {
@@ -226,14 +226,14 @@ export const generatePopAndHazardousComponentWarnings = (
 
   payload.wasteItems.forEach((wasteItem, index) => {
     if (
-      !wasteItem[popsOrHazardousbjectProperty]?.[containsPopsOrHazardousField]
+      !wasteItem[popsOrHazardousObjectProperty]?.[containsPopsOrHazardousField]
     ) {
       return
     }
 
     const sourceOfComponents =
-      wasteItem[popsOrHazardousbjectProperty].sourceOfComponents
-    const components = wasteItem[popsOrHazardousbjectProperty].components
+      wasteItem[popsOrHazardousObjectProperty].sourceOfComponents
+    const components = wasteItem[popsOrHazardousObjectProperty].components
 
     if (sourceOfComponents === 'NOT_PROVIDED') {
       return
@@ -242,7 +242,7 @@ export const generatePopAndHazardousComponentWarnings = (
     // Check if source is one of the values that expects components
     if (isPopOrHazardousComponentsEmpty(components)) {
       warnings.push({
-        key: `wasteItems[${index}].${popsOrHazardousbjectProperty}.components`,
+        key: `wasteItems[${index}].${popsOrHazardousObjectProperty}.components`,
         errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
         message: `${popsOrHazardous} components are recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
       })
@@ -250,7 +250,7 @@ export const generatePopAndHazardousComponentWarnings = (
 
     if (isPopOrHazardousConcentrationMissing(components)) {
       warnings.push({
-        key: `wasteItems[${index}].${popsOrHazardousbjectProperty}.components`,
+        key: `wasteItems[${index}].${popsOrHazardousObjectProperty}.components`,
         errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
         message: `${popsOrHazardous} concentration is recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
       })

--- a/src/common/helpers/validation-warnings.js
+++ b/src/common/helpers/validation-warnings.js
@@ -199,7 +199,7 @@ export const generateHazardousConsignmentWarnings = (payload) => {
 }
 
 /**
- * Generate warnings for POP components
+ * Generate warnings for POPs/Hazardous components
  *
  * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
  * 16     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   []                                        WARNING
@@ -208,39 +208,51 @@ export const generateHazardousConsignmentWarnings = (payload) => {
  * @param {Object} payload - The request payload
  * @returns {Array} Array of validation warnings for POPs
  */
-export const generatePopComponentWarnings = (payload) => {
+export const generatePopAndHazardousComponentWarnings = (
+  payload,
+  popsOrHazardous
+) => {
+  if (!['POPs', 'Hazardous'].includes(popsOrHazardous)) {
+    throw new Error('Expecting popsOrHazardous to be one of: POPs, Hazardous')
+  }
+
   const warnings = []
+  const popsOrHazardousbjectProperty = String(popsOrHazardous).toLowerCase()
+  const containsPopsOrHazardousField = `contains${String(popsOrHazardous).charAt(0).toUpperCase()}${String(popsOrHazardous).toLowerCase().slice(1)}`
 
   if (!Array.isArray(payload?.wasteItems)) {
     return warnings
   }
 
   payload.wasteItems.forEach((wasteItem, index) => {
-    if (!wasteItem.pops?.containsPops) {
+    if (
+      !wasteItem[popsOrHazardousbjectProperty]?.[containsPopsOrHazardousField]
+    ) {
       return
     }
 
-    const sourceOfComponents = wasteItem.pops.sourceOfComponents
-    const components = wasteItem.pops.components
+    const sourceOfComponents =
+      wasteItem[popsOrHazardousbjectProperty].sourceOfComponents
+    const components = wasteItem[popsOrHazardousbjectProperty].components
 
     if (sourceOfComponents === 'NOT_PROVIDED') {
       return
     }
 
     // Check if source is one of the values that expects components
-    if (isPopComponentsEmpty(components)) {
+    if (isPopOrHazardousComponentsEmpty(components)) {
       warnings.push({
-        key: `wasteItems[${index}].pops.components`,
+        key: `wasteItems[${index}].${popsOrHazardousbjectProperty}.components`,
         errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
-        message: `POP components are recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
+        message: `${popsOrHazardous} components are recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
       })
     }
 
-    if (isPopConcentrationMissing(components)) {
+    if (isPopOrHazardousConcentrationMissing(components)) {
       warnings.push({
-        key: `wasteItems[${index}].pops.components`,
+        key: `wasteItems[${index}].${popsOrHazardousbjectProperty}.components`,
         errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
-        message: `POP concentration is recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
+        message: `${popsOrHazardous} concentration is recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
       })
     }
   })
@@ -249,11 +261,12 @@ export const generatePopComponentWarnings = (payload) => {
 }
 
 /**
- * Determines if POP components is an empty array
- * @param {Object} components - The POP components
- * @returns {Boolean} True if POP components array is empty, otherwisse false
+ * Determines if POPs/Hazardous components is an empty array
+ * @param {Object} components - The POPs/Hazardous components
+ * @returns {Boolean} True if POPs/Hazardous components array is empty, otherwisse false
  */
-function isPopComponentsEmpty(components) {
+function isPopOrHazardousComponentsEmpty(components) {
+  console.log({ components, isArray: Array.isArray(components) })
   return (
     (Array.isArray(components) && components.length === 0) ||
     !Array.isArray(components)
@@ -261,13 +274,13 @@ function isPopComponentsEmpty(components) {
 }
 
 /**
- * Determines if any of the POP components has a missing concentration value
- * @param {Object} components - The POP components
- * @returns {Boolean} True if any of the POP components has a missing concentration value, otherwise false
+ * Determines if any of the POPs/Hazardous components has a missing concentration value
+ * @param {Object} components - The POPs/Hazardous components
+ * @returns {Boolean} True if any of the POPs/Hazardous components has a missing concentration value, otherwise false
  */
-function isPopConcentrationMissing(components) {
+function isPopOrHazardousConcentrationMissing(components) {
   return (
-    !isPopComponentsEmpty(components) &&
+    !isPopOrHazardousComponentsEmpty(components) &&
     components.some(
       (component) =>
         component.concentration === undefined ||
@@ -292,9 +305,16 @@ export const generateAllValidationWarnings = (payload) => {
   const consignmentWarnings = generateHazardousConsignmentWarnings(payload)
   warnings.push(...consignmentWarnings)
 
-  // Add POP components warnings
-  const popWarnings = generatePopComponentWarnings(payload)
-  warnings.push(...popWarnings)
+  // Add POPs components warnings
+  const popsWarnings = generatePopAndHazardousComponentWarnings(payload, 'POPs')
+  warnings.push(...popsWarnings)
+
+  // Add Hazardous components warnings
+  const hazardousWarnings = generatePopAndHazardousComponentWarnings(
+    payload,
+    'Hazardous'
+  )
+  warnings.push(...hazardousWarnings)
 
   return warnings
 }

--- a/src/common/helpers/validation-warnings.test.js
+++ b/src/common/helpers/validation-warnings.test.js
@@ -1,9 +1,8 @@
-import { sourceOfComponentsProvided } from '../constants/source-of-components.js'
+import { testPopsAndHazardousComponentWarnings } from '../../schemas/test-helpers/pops-and-hazardous-components-test-warnings-helpers.js'
 import {
   VALIDATION_ERROR_TYPES,
   generateDisposalRecoveryWarnings,
-  generateAllValidationWarnings,
-  generatePopComponentWarnings
+  generateAllValidationWarnings
 } from './validation-warnings.js'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -346,161 +345,8 @@ describe('Validation Warnings', () => {
     })
   })
 
-  describe('generatePopComponentWarnings', () => {
-    it.each([undefined, null])(
-      'should return empty array when payload is %s',
-      (value) => {
-        const payload = value
-
-        const warnings = generatePopComponentWarnings(payload)
-        expect(warnings).toEqual([])
-      }
-    )
-
-    it.each([undefined, null])(
-      'should return empty array when wasteItems is %s',
-      (value) => {
-        const payload = value
-
-        const warnings = generatePopComponentWarnings(payload)
-        expect(warnings).toEqual([])
-      }
-    )
-
-    it('should return empty array when containsPops is false', () => {
-      const payload = {
-        wasteItems: [
-          {
-            pops: {
-              containsPops: false
-            }
-          }
-        ]
-      }
-
-      const warnings = generatePopComponentWarnings(payload)
-      expect(warnings).toEqual([])
-    })
-
-    it('should return empty array when sourceOfComponents is NOT_PROVIDED', () => {
-      const payload = {
-        wasteItems: [
-          {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'NOT_PROVIDED'
-            }
-          }
-        ]
-      }
-
-      const warnings = generatePopComponentWarnings(payload)
-      expect(warnings).toEqual([])
-    })
-
-    it('should return empty array when POP components is provided with name and concentration values', () => {
-      const payload = {
-        wasteItems: [
-          {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'CARRIER_SUPPLIED',
-              components: [
-                {
-                  name: 'Aldrin',
-                  concentration: 100
-                },
-                {
-                  name: 'Chlordane',
-                  concentration: 30
-                }
-              ]
-            }
-          }
-        ]
-      }
-
-      const warnings = generatePopComponentWarnings(payload)
-      expect(warnings).toEqual([])
-    })
-
-    it('should generate warning when POP components is an empty array', () => {
-      const payload = {
-        wasteItems: [
-          {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'CARRIER_SUPPLIED',
-              components: []
-            }
-          }
-        ]
-      }
-
-      const warnings = generatePopComponentWarnings(payload)
-      expect(warnings).toEqual([
-        {
-          key: 'wasteItems[0].pops.components',
-          errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
-          message: `POP components are recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
-        }
-      ])
-    })
-
-    it.each([undefined, null])(
-      'should handle when POP components is not provided: "%s"',
-      (value) => {
-        const payload = {
-          wasteItems: [
-            {
-              pops: {
-                containsPops: true,
-                sourceOfComponents: 'CARRIER_SUPPLIED',
-                components: value
-              }
-            }
-          ]
-        }
-
-        generatePopComponentWarnings(payload)
-      }
-    )
-
-    it.each([undefined, null])(
-      'should generate warning when POP components is provided with a missing concentration value: "%s"',
-      (value) => {
-        const payload = {
-          wasteItems: [
-            {
-              pops: {
-                containsPops: true,
-                sourceOfComponents: 'CARRIER_SUPPLIED',
-                components: [
-                  {
-                    name: 'Aldrin',
-                    concentration: 100
-                  },
-                  {
-                    name: 'Chlordane',
-                    concentration: value
-                  }
-                ]
-              }
-            }
-          ]
-        }
-
-        const warnings = generatePopComponentWarnings(payload)
-        expect(warnings).toEqual([
-          {
-            key: 'wasteItems[0].pops.components',
-            errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
-            message: `POP concentration is recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
-          }
-        ])
-      }
-    )
-  })
+  testPopsAndHazardousComponentWarnings('POPs')
+  testPopsAndHazardousComponentWarnings('Hazardous')
 
   describe('generateAllValidationWarnings', () => {
     it('should return empty array when no warnings are generated', () => {

--- a/src/schemas/test-helpers/pops-and-hazardous-components-test-helpers.js
+++ b/src/schemas/test-helpers/pops-and-hazardous-components-test-helpers.js
@@ -1,0 +1,434 @@
+import {
+  sourceOfComponentsProvided,
+  validSourceOfComponents
+} from '../../common/constants/source-of-components.js'
+import { receiveMovementRequestSchema } from '../receipt.js'
+import { createTestPayload } from './waste-test-helpers.js'
+
+export function testPopsAndHazardousComponents(popsOrHazardous) {
+  if (!['POPs', 'Hazardous'].includes(popsOrHazardous)) {
+    throw new Error('Expecting popsOrHazardous to be one of: POPs, Hazardous')
+  }
+
+  const popsOrHazardousbjectProperty = String(popsOrHazardous).toLowerCase()
+  const containsPopsOrHazardousField = `contains${String(popsOrHazardous).charAt(0).toUpperCase()}${String(popsOrHazardous).toLowerCase().slice(1)}`
+
+  describe(`Components Validation`, () => {
+    for (const containsHazardousValue of [true, false]) {
+      /*
+       * item   contains<Haz/Pops>	sourceOfComponents	                    components  expected outcome
+       * 1	    FALSE			          NOT_PROVIDED		                        []				  ACCEPT
+       * 6	    FALSE			          Other (e.g GUIDANCE, OWN TESTING etc)   []          ACCEPT
+       * 11     TRUE                NOT_PROVIDED                            []          ACCEPT
+       * 16     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   []          WARNING
+       */
+      it.each(Object.values(validSourceOfComponents))(
+        `should accept components when components is [], ${containsPopsOrHazardousField} is ${containsHazardousValue} and sourceOfComponents is %s`,
+        (value) => {
+          const payload = createTestPayload({
+            wasteItemOverrides: {
+              [popsOrHazardousbjectProperty]: {
+                [containsPopsOrHazardousField]: containsHazardousValue,
+                sourceOfComponents: value,
+                components: []
+              }
+            }
+          })
+          const result = receiveMovementRequestSchema.validate(payload)
+          expect(result.error).toBeUndefined()
+        }
+      )
+
+      /*
+       * item   contains<Haz/Pops>	sourceOfComponents	                    components  expected outcome
+       * 2	    FALSE			          NOT_PROVIDED		                        [{}] 			  REJECT
+       * 7      FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{}]        REJECT
+       * 12     TRUE                NOT_PROVIDED                            [{}]        REJECT
+       * 17     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{}]        REJECT
+       */
+      it.each(Object.values(validSourceOfComponents))(
+        `should reject components when an empty component is provided, ${containsPopsOrHazardousField} is ${containsHazardousValue} and sourceOfComponents is %s`,
+        (value) => {
+          const payload = createTestPayload({
+            wasteItemOverrides: {
+              [popsOrHazardousbjectProperty]: {
+                [containsPopsOrHazardousField]: containsHazardousValue,
+                sourceOfComponents: value,
+                components: [
+                  {
+                    name: 'Aldrin',
+                    concentration: 100
+                  },
+                  {}
+                ]
+              }
+            }
+          })
+          const result = receiveMovementRequestSchema.validate(payload)
+          expect(result.error).toBeDefined()
+          expect(result.error.message).toBe(
+            `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].name" is required`
+          )
+        }
+      )
+    }
+
+    /*
+     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
+     * 3	    FALSE			          NOT_PROVIDED		                        [{ name: 'Aldrin' }]			                REJECT
+     * 8      FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin' }]                      REJECT
+     * 4	    FALSE			          NOT_PROVIDED		                        [{ concentration: 1.8 }]			            REJECT
+     * 5	    FALSE			          NOT_PROVIDED		                        [{ name: 'Aldrin', concentration: 1.8 }]  REJECT
+     * 9      FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{ concentration: 1.8 }]                  REJECT
+     * 10     FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin', concentration: 1.8 }]  REJECT
+     */
+    it.each(Object.values(validSourceOfComponents))(
+      `should reject when components are provided, ${containsPopsOrHazardousField} is false and sourceOfComponents is %s`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: false,
+              sourceOfComponents: value,
+              components: [
+                {
+                  name: 'Aldrin',
+                  concentration: 100
+                }
+              ]
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toBe(
+          `${popsOrHazardous} components must not be provided when ${popsOrHazardous} components are not present`
+        )
+      }
+    )
+
+    /*
+     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
+     * 13     TRUE                NOT_PROVIDED                            [{ name: 'Aldrin' }]                      REJECT
+     * 14     TRUE                NOT_PROVIDED                            [{ concentration: 1.8 }]                  REJECT
+     * 15     TRUE                NOT_PROVIDED                            [{ name: 'Aldrin', concentration: 1.8 }]  REJECT
+     */
+    it(`should reject when components are provided, ${containsPopsOrHazardousField} is true and sourceOfComponents is "NOT_PROVIDED`, () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: {
+          [popsOrHazardousbjectProperty]: {
+            [containsPopsOrHazardousField]: true,
+            sourceOfComponents: 'NOT_PROVIDED',
+            components: [
+              {
+                name: 'Aldrin',
+                concentration: 100
+              }
+            ]
+          }
+        }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toBe(
+        `${popsOrHazardous} components must not be provided when the source of components is NOT_PROVIDED`
+      )
+    })
+
+    /*
+     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
+     * 20     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin', concentration: 1.8 }]  ACCEPT
+     */
+    it.each(Object.values(sourceOfComponentsProvided))(
+      `should accept when components are provided, ${containsPopsOrHazardousField} is true and sourceOfComponents is %s`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: value,
+              components: [
+                {
+                  name: 'Aldrin',
+                  concentration: 100
+                }
+              ]
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeUndefined()
+      }
+    )
+
+    /*
+     * item   contains<Haz/Pops>	sourceOfComponents	                    components			          expected outcome
+     * 19     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{ concentration: 1.8 }]  REJECT
+     */
+    it.each([undefined, null])(
+      `should reject when components are provided without a name, ${containsPopsOrHazardousField} is true and sourceOfComponents is other than NOT_PROVIDED`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'CARRIER_PROVIDED',
+              components: [
+                {
+                  name: 'Aldrin',
+                  concentration: 100
+                },
+                {
+                  name: value,
+                  concentration: 30
+                }
+              ]
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toBe(
+          `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].name" is required`
+        )
+      }
+    )
+
+    /*
+     * item   contains<Haz/Pops>	sourceOfComponents	                    components			      expected outcome
+     * 18     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin' }]  WARNING
+     */
+    it.each([undefined, null])(
+      `should accept when components are provided without a concentration, ${containsPopsOrHazardousField} is true and sourceOfComponents is other than NOT_PROVIDED`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'CARRIER_PROVIDED',
+              components: [
+                {
+                  name: 'Aldrin',
+                  concentration: 100
+                },
+                {
+                  name: 'Chlordane',
+                  concentration: value
+                }
+              ]
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeUndefined()
+      }
+    )
+
+    it('should reject invalid POP name: ""', () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: {
+          [popsOrHazardousbjectProperty]: {
+            [containsPopsOrHazardousField]: true,
+            sourceOfComponents: 'CARRIER_PROVIDED',
+            components: [
+              {
+                name: 'Aldrin',
+                concentration: 100
+              },
+              {
+                name: '',
+                concentration: 100
+              }
+            ]
+          }
+        }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toBe(
+        `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].name" is not allowed to be empty`
+      )
+    })
+
+    it.each([12.5, 9.12345678, 500, 0])(
+      'should accept valid POP concentration value: "%s"',
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'CARRIER_PROVIDED',
+              components: [
+                {
+                  name: 'Aldrin',
+                  concentration: 100
+                },
+                {
+                  name: 'Aldrin',
+                  concentration: value
+                }
+              ]
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeUndefined()
+      }
+    )
+
+    it(`should reject components when ${containsPopsOrHazardousField} is true and concentration is not a number`, () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: {
+          [popsOrHazardousbjectProperty]: {
+            [containsPopsOrHazardousField]: true,
+            sourceOfComponents: 'OWN_TESTING',
+            components: [
+              {
+                name: 'Aldrin',
+                concentration: 100
+              },
+              {
+                name: 'Endosulfan',
+                concentration: 'ten'
+              }
+            ]
+          }
+        }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toBe(
+        `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].concentration" must be a valid number`
+      )
+    })
+
+    it(`should reject components when ${containsPopsOrHazardousField} is true and concentration is a negative number`, () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: {
+          [popsOrHazardousbjectProperty]: {
+            [containsPopsOrHazardousField]: true,
+            sourceOfComponents: 'OWN_TESTING',
+            components: [
+              {
+                name: 'Aldrin',
+                concentration: 100
+              },
+              {
+                name: 'Endosulfan',
+                concentration: -10
+              }
+            ]
+          }
+        }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toBe(
+        `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].concentration" concentration cannot be negative`
+      )
+    })
+
+    it(`should reject components when ${containsPopsOrHazardousField} is true and sourceOfComponents is missing`, () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: {
+          [popsOrHazardousbjectProperty]: {
+            [containsPopsOrHazardousField]: true
+          }
+        }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toBe(
+        `"wasteItems[0].${popsOrHazardousbjectProperty}.sourceOfComponents" is required when ${popsOrHazardous} components are present`
+      )
+    })
+
+    it(`should reject components when ${containsPopsOrHazardousField} is true and sourceOfComponents is invalid`, () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: {
+          [popsOrHazardousbjectProperty]: {
+            [containsPopsOrHazardousField]: true,
+            sourceOfComponents: 'INVALID_SOURCE',
+            components: [
+              {
+                name: 'Aldrin',
+                concentration: 100
+              }
+            ]
+          }
+        }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toBe(
+        `"wasteItems[0].${popsOrHazardousbjectProperty}.sourceOfComponents" must be one of [${Object.values(validSourceOfComponents).join(', ')}]`
+      )
+    })
+
+    it.each([undefined, null])(
+      `should accept components when ${containsPopsOrHazardousField} is false and no components are provided: "%s"`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: false,
+              components: value
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeUndefined()
+      }
+    )
+
+    it.each([undefined, null])(
+      `should reject components when ${containsPopsOrHazardousField} is true, sourceOfComponents is other than NOT_PROVIDED and no components are provided: "%s"`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'CARRIER_PROVIDED',
+              components: value
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toBe(
+          `"wasteItems[0].${popsOrHazardousbjectProperty}.components" is required when ${popsOrHazardous} components are present`
+        )
+      }
+    )
+
+    it.each([undefined, null])(
+      `should accept components when ${containsPopsOrHazardousField} is true, sourceOfComponents is NOT_PROVIDED and no components are provided: "%s"`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'NOT_PROVIDED',
+              components: value
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeUndefined()
+      }
+    )
+
+    it.each([undefined, null])(
+      `should accept components when ${containsPopsOrHazardousField} is not provided: "%s"`,
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            [popsOrHazardousbjectProperty]: value
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeUndefined()
+      }
+    )
+  })
+}

--- a/src/schemas/test-helpers/pops-and-hazardous-components-test-helpers.js
+++ b/src/schemas/test-helpers/pops-and-hazardous-components-test-helpers.js
@@ -10,7 +10,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
     throw new Error('Expecting popsOrHazardous to be one of: POPs, Hazardous')
   }
 
-  const popsOrHazardousbjectProperty = String(popsOrHazardous).toLowerCase()
+  const popsOrHazardousObjectProperty = String(popsOrHazardous).toLowerCase()
   const containsPopsOrHazardousField = `contains${String(popsOrHazardous).charAt(0).toUpperCase()}${String(popsOrHazardous).toLowerCase().slice(1)}`
 
   describe(`Components Validation`, () => {
@@ -27,7 +27,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
         (value) => {
           const payload = createTestPayload({
             wasteItemOverrides: {
-              [popsOrHazardousbjectProperty]: {
+              [popsOrHazardousObjectProperty]: {
                 [containsPopsOrHazardousField]: containsHazardousValue,
                 sourceOfComponents: value,
                 components: []
@@ -51,7 +51,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
         (value) => {
           const payload = createTestPayload({
             wasteItemOverrides: {
-              [popsOrHazardousbjectProperty]: {
+              [popsOrHazardousObjectProperty]: {
                 [containsPopsOrHazardousField]: containsHazardousValue,
                 sourceOfComponents: value,
                 components: [
@@ -67,7 +67,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
           const result = receiveMovementRequestSchema.validate(payload)
           expect(result.error).toBeDefined()
           expect(result.error.message).toBe(
-            `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].name" is required`
+            `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].name" is required`
           )
         }
       )
@@ -87,7 +87,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: false,
               sourceOfComponents: value,
               components: [
@@ -116,7 +116,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
     it(`should reject when components are provided, ${containsPopsOrHazardousField} is true and sourceOfComponents is "NOT_PROVIDED`, () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
-          [popsOrHazardousbjectProperty]: {
+          [popsOrHazardousObjectProperty]: {
             [containsPopsOrHazardousField]: true,
             sourceOfComponents: 'NOT_PROVIDED',
             components: [
@@ -144,7 +144,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: value,
               components: [
@@ -170,7 +170,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'CARRIER_PROVIDED',
               components: [
@@ -189,7 +189,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
         const result = receiveMovementRequestSchema.validate(payload)
         expect(result.error).toBeDefined()
         expect(result.error.message).toBe(
-          `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].name" is required`
+          `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].name" is required`
         )
       }
     )
@@ -203,7 +203,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'CARRIER_PROVIDED',
               components: [
@@ -227,7 +227,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
     it('should reject invalid POP name: ""', () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
-          [popsOrHazardousbjectProperty]: {
+          [popsOrHazardousObjectProperty]: {
             [containsPopsOrHazardousField]: true,
             sourceOfComponents: 'CARRIER_PROVIDED',
             components: [
@@ -246,7 +246,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       const result = receiveMovementRequestSchema.validate(payload)
       expect(result.error).toBeDefined()
       expect(result.error.message).toBe(
-        `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].name" is not allowed to be empty`
+        `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].name" is not allowed to be empty`
       )
     })
 
@@ -255,7 +255,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'CARRIER_PROVIDED',
               components: [
@@ -279,7 +279,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
     it(`should reject components when ${containsPopsOrHazardousField} is true and concentration is not a number`, () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
-          [popsOrHazardousbjectProperty]: {
+          [popsOrHazardousObjectProperty]: {
             [containsPopsOrHazardousField]: true,
             sourceOfComponents: 'OWN_TESTING',
             components: [
@@ -298,14 +298,14 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       const result = receiveMovementRequestSchema.validate(payload)
       expect(result.error).toBeDefined()
       expect(result.error.message).toBe(
-        `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].concentration" must be a valid number`
+        `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].concentration" must be a valid number`
       )
     })
 
     it(`should reject components when ${containsPopsOrHazardousField} is true and concentration is a negative number`, () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
-          [popsOrHazardousbjectProperty]: {
+          [popsOrHazardousObjectProperty]: {
             [containsPopsOrHazardousField]: true,
             sourceOfComponents: 'OWN_TESTING',
             components: [
@@ -324,14 +324,14 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       const result = receiveMovementRequestSchema.validate(payload)
       expect(result.error).toBeDefined()
       expect(result.error.message).toBe(
-        `"wasteItems[0].${popsOrHazardousbjectProperty}.components[1].concentration" concentration cannot be negative`
+        `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].concentration" concentration cannot be negative`
       )
     })
 
     it(`should reject components when ${containsPopsOrHazardousField} is true and sourceOfComponents is missing`, () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
-          [popsOrHazardousbjectProperty]: {
+          [popsOrHazardousObjectProperty]: {
             [containsPopsOrHazardousField]: true
           }
         }
@@ -339,14 +339,14 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       const result = receiveMovementRequestSchema.validate(payload)
       expect(result.error).toBeDefined()
       expect(result.error.message).toBe(
-        `"wasteItems[0].${popsOrHazardousbjectProperty}.sourceOfComponents" is required when ${popsOrHazardous} components are present`
+        `"wasteItems[0].${popsOrHazardousObjectProperty}.sourceOfComponents" is required when ${popsOrHazardous} components are present`
       )
     })
 
     it(`should reject components when ${containsPopsOrHazardousField} is true and sourceOfComponents is invalid`, () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
-          [popsOrHazardousbjectProperty]: {
+          [popsOrHazardousObjectProperty]: {
             [containsPopsOrHazardousField]: true,
             sourceOfComponents: 'INVALID_SOURCE',
             components: [
@@ -361,7 +361,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       const result = receiveMovementRequestSchema.validate(payload)
       expect(result.error).toBeDefined()
       expect(result.error.message).toBe(
-        `"wasteItems[0].${popsOrHazardousbjectProperty}.sourceOfComponents" must be one of [${Object.values(validSourceOfComponents).join(', ')}]`
+        `"wasteItems[0].${popsOrHazardousObjectProperty}.sourceOfComponents" must be one of [${Object.values(validSourceOfComponents).join(', ')}]`
       )
     })
 
@@ -370,7 +370,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: false,
               components: value
             }
@@ -386,7 +386,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'CARRIER_PROVIDED',
               components: value
@@ -396,7 +396,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
         const result = receiveMovementRequestSchema.validate(payload)
         expect(result.error).toBeDefined()
         expect(result.error.message).toBe(
-          `"wasteItems[0].${popsOrHazardousbjectProperty}.components" is required when ${popsOrHazardous} components are present`
+          `"wasteItems[0].${popsOrHazardousObjectProperty}.components" is required when ${popsOrHazardous} components are present`
         )
       }
     )
@@ -406,7 +406,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'NOT_PROVIDED',
               components: value
@@ -423,7 +423,7 @@ export function testPopsAndHazardousComponents(popsOrHazardous) {
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
-            [popsOrHazardousbjectProperty]: value
+            [popsOrHazardousObjectProperty]: value
           }
         })
         const result = receiveMovementRequestSchema.validate(payload)

--- a/src/schemas/test-helpers/pops-and-hazardous-components-test-warnings-helpers.js
+++ b/src/schemas/test-helpers/pops-and-hazardous-components-test-warnings-helpers.js
@@ -1,0 +1,191 @@
+import { sourceOfComponentsProvided } from '../../common/constants/source-of-components.js'
+import {
+  generatePopAndHazardousComponentWarnings,
+  VALIDATION_ERROR_TYPES
+} from '../../common/helpers/validation-warnings.js'
+
+export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
+  if (!['POPs', 'Hazardous'].includes(popsOrHazardous)) {
+    throw new Error('Expecting popsOrHazardous to be one of: POPs, Hazardous')
+  }
+
+  const popsOrHazardousbjectProperty = String(popsOrHazardous).toLowerCase()
+  const containsPopsOrHazardousField = `contains${String(popsOrHazardous).charAt(0).toUpperCase()}${String(popsOrHazardous).toLowerCase().slice(1)}`
+
+  describe(`generatePopAndHazardousComponentWarnings: "${popsOrHazardous}"`, () => {
+    it.each([undefined, null])(
+      'should return empty array when payload is %s',
+      (value) => {
+        const payload = value
+
+        const warnings = generatePopAndHazardousComponentWarnings(
+          payload,
+          popsOrHazardous
+        )
+        expect(warnings).toEqual([])
+      }
+    )
+
+    it.each([undefined, null])(
+      'should return empty array when wasteItems is %s',
+      (value) => {
+        const payload = value
+
+        const warnings = generatePopAndHazardousComponentWarnings(
+          payload,
+          popsOrHazardous
+        )
+        expect(warnings).toEqual([])
+      }
+    )
+
+    it(`should return empty array when ${containsPopsOrHazardousField} is false`, () => {
+      const payload = {
+        wasteItems: [
+          {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: false
+            }
+          }
+        ]
+      }
+
+      const warnings = generatePopAndHazardousComponentWarnings(
+        payload,
+        popsOrHazardous
+      )
+      expect(warnings).toEqual([])
+    })
+
+    it('should return empty array when sourceOfComponents is NOT_PROVIDED', () => {
+      const payload = {
+        wasteItems: [
+          {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'NOT_PROVIDED'
+            }
+          }
+        ]
+      }
+
+      const warnings = generatePopAndHazardousComponentWarnings(
+        payload,
+        popsOrHazardous
+      )
+      expect(warnings).toEqual([])
+    })
+
+    it(`should return empty array when ${popsOrHazardous} components is provided with name and concentration values`, () => {
+      const payload = {
+        wasteItems: [
+          {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'CARRIER_SUPPLIED',
+              components: [
+                {
+                  name: 'Aldrin',
+                  concentration: 100
+                },
+                {
+                  name: 'Chlordane',
+                  concentration: 30
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      const warnings = generatePopAndHazardousComponentWarnings(
+        payload,
+        popsOrHazardous
+      )
+      expect(warnings).toEqual([])
+    })
+
+    it(`should generate warning when ${popsOrHazardous} components is an empty array`, () => {
+      const payload = {
+        wasteItems: [
+          {
+            [popsOrHazardousbjectProperty]: {
+              [containsPopsOrHazardousField]: true,
+              sourceOfComponents: 'CARRIER_SUPPLIED',
+              components: []
+            }
+          }
+        ]
+      }
+
+      const warnings = generatePopAndHazardousComponentWarnings(
+        payload,
+        popsOrHazardous
+      )
+      expect(warnings).toEqual([
+        {
+          key: `wasteItems[0].${popsOrHazardousbjectProperty}.components`,
+          errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
+          message: `${popsOrHazardous} components are recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
+        }
+      ])
+    })
+
+    it.each([undefined, null])(
+      `should handle when ${popsOrHazardous} components is not provided: "%s"`,
+      (value) => {
+        const payload = {
+          wasteItems: [
+            {
+              [popsOrHazardousbjectProperty]: {
+                [containsPopsOrHazardousField]: true,
+                sourceOfComponents: 'CARRIER_SUPPLIED',
+                components: value
+              }
+            }
+          ]
+        }
+
+        generatePopAndHazardousComponentWarnings(payload, popsOrHazardous)
+      }
+    )
+
+    it.each([undefined, null])(
+      `should generate warning when ${popsOrHazardous} components is provided with a missing concentration value: "%s"`,
+      (value) => {
+        const payload = {
+          wasteItems: [
+            {
+              [popsOrHazardousbjectProperty]: {
+                [containsPopsOrHazardousField]: true,
+                sourceOfComponents: 'CARRIER_SUPPLIED',
+                components: [
+                  {
+                    name: 'Aldrin',
+                    concentration: 100
+                  },
+                  {
+                    name: 'Chlordane',
+                    concentration: value
+                  }
+                ]
+              }
+            }
+          ]
+        }
+
+        const warnings = generatePopAndHazardousComponentWarnings(
+          payload,
+          popsOrHazardous
+        )
+        expect(warnings).toEqual([
+          {
+            key: `wasteItems[0].${popsOrHazardousbjectProperty}.components`,
+            errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
+            message: `${popsOrHazardous} concentration is recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
+          }
+        ])
+      }
+    )
+  })
+}

--- a/src/schemas/test-helpers/pops-and-hazardous-components-test-warnings-helpers.js
+++ b/src/schemas/test-helpers/pops-and-hazardous-components-test-warnings-helpers.js
@@ -9,7 +9,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
     throw new Error('Expecting popsOrHazardous to be one of: POPs, Hazardous')
   }
 
-  const popsOrHazardousbjectProperty = String(popsOrHazardous).toLowerCase()
+  const popsOrHazardousObjectProperty = String(popsOrHazardous).toLowerCase()
   const containsPopsOrHazardousField = `contains${String(popsOrHazardous).charAt(0).toUpperCase()}${String(popsOrHazardous).toLowerCase().slice(1)}`
 
   describe(`generatePopAndHazardousComponentWarnings: "${popsOrHazardous}"`, () => {
@@ -43,7 +43,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
       const payload = {
         wasteItems: [
           {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: false
             }
           }
@@ -61,7 +61,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
       const payload = {
         wasteItems: [
           {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'NOT_PROVIDED'
             }
@@ -80,7 +80,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
       const payload = {
         wasteItems: [
           {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'CARRIER_SUPPLIED',
               components: [
@@ -109,7 +109,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
       const payload = {
         wasteItems: [
           {
-            [popsOrHazardousbjectProperty]: {
+            [popsOrHazardousObjectProperty]: {
               [containsPopsOrHazardousField]: true,
               sourceOfComponents: 'CARRIER_SUPPLIED',
               components: []
@@ -124,7 +124,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
       )
       expect(warnings).toEqual([
         {
-          key: `wasteItems[0].${popsOrHazardousbjectProperty}.components`,
+          key: `wasteItems[0].${popsOrHazardousObjectProperty}.components`,
           errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
           message: `${popsOrHazardous} components are recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
         }
@@ -137,7 +137,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
         const payload = {
           wasteItems: [
             {
-              [popsOrHazardousbjectProperty]: {
+              [popsOrHazardousObjectProperty]: {
                 [containsPopsOrHazardousField]: true,
                 sourceOfComponents: 'CARRIER_SUPPLIED',
                 components: value
@@ -156,7 +156,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
         const payload = {
           wasteItems: [
             {
-              [popsOrHazardousbjectProperty]: {
+              [popsOrHazardousObjectProperty]: {
                 [containsPopsOrHazardousField]: true,
                 sourceOfComponents: 'CARRIER_SUPPLIED',
                 components: [
@@ -180,7 +180,7 @@ export function testPopsAndHazardousComponentWarnings(popsOrHazardous) {
         )
         expect(warnings).toEqual([
           {
-            key: `wasteItems[0].${popsOrHazardousbjectProperty}.components`,
+            key: `wasteItems[0].${popsOrHazardousObjectProperty}.components`,
             errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
             message: `${popsOrHazardous} concentration is recommended when source of components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
           }

--- a/src/schemas/waste-hazardous.test.js
+++ b/src/schemas/waste-hazardous.test.js
@@ -1,10 +1,10 @@
 import { validHazCodes } from '../common/constants/haz-codes.js'
 import {
   sourceOfComponentsNotProvided,
-  sourceOfComponentsProvided,
   validSourceOfComponents
 } from '../common/constants/source-of-components.js'
 import { receiveMovementRequestSchema } from './receipt.js'
+import { testPopsAndHazardousComponents } from './test-helpers/pops-and-hazardous-components-test-helpers.js'
 import { createTestPayload } from './test-helpers/waste-test-helpers.js'
 
 describe('Receipt Schema Validation - Hazardous', () => {
@@ -16,230 +16,6 @@ describe('Receipt Schema Validation - Hazardous', () => {
       })
       return receiveMovementRequestSchema.validate(payload)
     }
-
-    describe('Hazardous validation scenarios', () => {
-      describe('Valid hazardous scenarios', () => {
-        const validTestCases = [
-          {
-            description: 'valid hazardous indicator (false)',
-            input: {
-              containsHazardous: false,
-              sourceOfComponents: sourceOfComponentsNotProvided.NOT_PROVIDED
-            }
-          },
-          {
-            description: 'hazardous with components array',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              components: [
-                { name: 'Mercury', concentration: 30 },
-                { name: 'Lead', concentration: 15 }
-              ]
-            }
-          },
-          {
-            description: 'hazardous with both hazCodes and components',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              hazCodes: ['HP_1', 'HP_2'],
-              components: [{ name: 'Mercury', concentration: 30 }]
-            }
-          },
-          {
-            description:
-              'when sourceOfComponents is NOT_PROVIDED then components can be undefined',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: sourceOfComponentsNotProvided.NOT_PROVIDED,
-              components: undefined
-            }
-          },
-          {
-            description: 'missing hazardous section',
-            input: undefined
-          }
-        ]
-
-        it.each(validTestCases)('should accept $description', ({ input }) => {
-          const result = validateHazardous(input)
-          expect(result.error).toBeUndefined()
-        })
-
-        it.each(Object.values(validSourceOfComponents))(
-          'components can be an empty array when sourceOfComponents is %s',
-          (componentSource) => {
-            const result = validateHazardous({
-              containsHazardous: true,
-              sourceOfComponents: componentSource,
-              components: []
-            })
-            expect(result.error).toBeUndefined()
-          }
-        )
-
-        it.each(Object.values(sourceOfComponentsProvided))(
-          'when sourceOfComponents is %s then components can be provided with name missing',
-          (componentSource) => {
-            const result = validateHazardous({
-              containsHazardous: true,
-              sourceOfComponents: componentSource,
-              components: [{ name: undefined, concentration: 30 }]
-            })
-            expect(result.error).toBeUndefined()
-          }
-        )
-
-        it.each(Object.values(sourceOfComponentsProvided))(
-          'when sourceOfComponents is %s then components can be provided with concentration missing',
-          (componentSource) => {
-            const result = validateHazardous({
-              containsHazardous: true,
-              sourceOfComponents: componentSource,
-              components: [{ name: 'Mercury', concentration: undefined }]
-            })
-            expect(result.error).toBeUndefined()
-          }
-        )
-
-        it.each(Object.values(sourceOfComponentsProvided))(
-          'when sourceOfComponents is %s then components can be provided with name and concentration missing',
-          (componentSource) => {
-            const result = validateHazardous({
-              containsHazardous: true,
-              sourceOfComponents: componentSource,
-              components: [{ name: undefined, concentration: undefined }]
-            })
-            expect(result.error).toBeUndefined()
-          }
-        )
-      })
-
-      describe('Invalid hazardous scenarios', () => {
-        const invalidTestCases = [
-          {
-            description:
-              'missing containsHazardous field when hazardous object exists',
-            input: { hazCodes: ['HP_1', 'HP_2', 'HP_3'] },
-            errorMessage:
-              'Hazardous waste is any waste that is potentially harmful to human health or the environment.'
-          },
-          {
-            description: 'invalid concentration string that is not allowed',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              components: [{ name: 'Mercury', concentration: 'invalid' }]
-            },
-            errorMessage:
-              'Chemical or Biological concentration must be a valid number or "Not Supplied"'
-          },
-          {
-            description: 'invalid concentration type (object)',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              components: [{ name: 'Mercury', concentration: {} }]
-            },
-            errorMessage:
-              'Chemical or Biological concentration must be a valid number or "Not Supplied"'
-          },
-          {
-            description: 'invalid hazCodes types (string)',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              hazCodes: ['HP 1', 'HP2']
-            },
-            errorMessage: `"wasteItems[0].hazardous.hazCodes[0]" must be one of [${validHazCodes.join(', ')}]`
-          },
-          {
-            description: 'invalid hazCodes types (undefined)',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              hazCodes: [undefined]
-            },
-            errorMessage: '"HazardCodes" must not be a sparse array item'
-          },
-          {
-            description: 'invalid hazCodes types (null)',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              hazCodes: [null]
-            },
-            errorMessage: `"wasteItems[0].hazardous.hazCodes[0]" must be one of [${validHazCodes.join(', ')}]`
-          },
-          {
-            description: 'invalid source of components (string)',
-            input: { containsHazardous: true, sourceOfComponents: 'INVALID' },
-            errorMessage: `"wasteItems[0].hazardous.sourceOfComponents" must be one of [${Object.values(validSourceOfComponents).join(', ')}]`
-          },
-          {
-            description: 'invalid source of components (undefined)',
-            input: { containsHazardous: true, sourceOfComponents: undefined },
-            errorMessage:
-              'Chemical or Biological component name and Source of Components must be specified when hazardous properties are present'
-          },
-          {
-            description: 'invalid source of components (null)',
-            input: { containsHazardous: true, sourceOfComponents: null },
-            errorMessage: `"wasteItems[0].hazardous.sourceOfComponents" must be one of [${Object.values(validSourceOfComponents).join(', ')}]`
-          },
-          {
-            description:
-              'when source of components is NOT_PROVIDED then components cannot be provided',
-            input: {
-              containsHazardous: true,
-              sourceOfComponents: sourceOfComponentsNotProvided.NOT_PROVIDED,
-              components: [{ name: 'Mercury', concentration: 30 }]
-            },
-            errorMessage: `"wasteItems[0].hazardous.components" must either be an empty array or not provided if sourceOfComponents is ${sourceOfComponentsNotProvided.NOT_PROVIDED}`
-          }
-        ]
-
-        it.each(invalidTestCases)(
-          'should reject $description',
-          ({ input, errorMessage }) => {
-            const result = validateHazardous(input)
-            expect(result.error).toBeDefined()
-            expect(result.error.message).toContain(errorMessage)
-          }
-        )
-      })
-
-      it.each(Object.values(sourceOfComponentsProvided))(
-        'components cannot be undefined when sourceOfComponents is %s',
-        (componentSource) => {
-          const result = validateHazardous({
-            containsHazardous: true,
-            sourceOfComponents: componentSource,
-            components: undefined
-          })
-          expect(result.error).toBeDefined()
-          expect(result.error.message).toContain(
-            `Components is required when Source of Components is one of ${Object.values(sourceOfComponentsProvided).join(', ')}`
-          )
-        }
-      )
-
-      it.each(Object.values(validSourceOfComponents))(
-        'components cannot be null when sourceOfComponents is %s',
-        (componentSource) => {
-          const result = validateHazardous({
-            containsHazardous: true,
-            sourceOfComponents: componentSource,
-            components: null
-          })
-          expect(result.error).toBeDefined()
-          expect(result.error.message).toContain(
-            '"wasteItems[0].hazardous.components" must be an array'
-          )
-        }
-      )
-    })
 
     // Test scenarios from user story
     describe('HP Code Validation Scenarios', () => {
@@ -276,7 +52,7 @@ describe('Receipt Schema Validation - Hazardous', () => {
           containsHazardous: true,
           sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
           hazCodes: [],
-          components: [{ name: 'Mercury', concentration: 'Not Supplied' }]
+          components: [{ name: 'Mercury', concentration: 15 }]
         })
         expect(result.error).toBeUndefined()
       })
@@ -379,331 +155,46 @@ describe('Receipt Schema Validation - Hazardous', () => {
         )
       })
     })
+
+    const invalidTestCases = [
+      {
+        description: 'invalid hazCodes types (string)',
+        input: {
+          containsHazardous: true,
+          sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
+          hazCodes: ['HP 1', 'HP2']
+        },
+        errorMessage: `"wasteItems[0].hazardous.hazCodes[0]" must be one of [${validHazCodes.join(', ')}]`
+      },
+      {
+        description: 'invalid hazCodes types (undefined)',
+        input: {
+          containsHazardous: true,
+          sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
+          hazCodes: [undefined]
+        },
+        errorMessage: '"HazardCodes" must not be a sparse array item'
+      },
+      {
+        description: 'invalid hazCodes types (null)',
+        input: {
+          containsHazardous: true,
+          sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
+          hazCodes: [null]
+        },
+        errorMessage: `"wasteItems[0].hazardous.hazCodes[0]" must be one of [${validHazCodes.join(', ')}]`
+      }
+    ]
+
+    it.each(invalidTestCases)(
+      'should reject $description',
+      ({ input, errorMessage }) => {
+        const result = validateHazardous(input)
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toContain(errorMessage)
+      }
+    )
   })
 
-  describe('Chemical/Biological Concentration Validation', () => {
-    // Helper function to validate a payload with hazardous waste and components
-    const validateHazardousWithComponents = (
-      containsHazardous,
-      components,
-      sourceOfComponents = sourceOfComponentsProvided.CARRIER_PROVIDED
-    ) => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          hazardous: {
-            containsHazardous,
-            sourceOfComponents,
-            ...(components && { components })
-          }
-        }
-      })
-      return receiveMovementRequestSchema.validate(payload)
-    }
-
-    describe('When waste contains hazardous properties', () => {
-      it('should accept valid numerical concentration values', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: 30
-          }
-        ])
-        expect(result.error).toBeUndefined()
-      })
-
-      it('should accept "Not Supplied" as concentration value', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: 'Not Supplied'
-          }
-        ])
-        expect(result.error).toBeUndefined()
-      })
-
-      it('should accept blank concentration value with warning', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: ''
-          }
-        ])
-        expect(result.error).toBeUndefined()
-      })
-
-      it('should reject negative concentration values', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: -10
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological concentration cannot be negative'
-        )
-      })
-
-      it('should reject invalid concentration values', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: 'Invalid'
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological concentration must be a valid number or "Not Supplied"'
-        )
-      })
-
-      it('should reject numeric string concentration values', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: '30'
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological concentration must be a valid number or "Not Supplied"'
-        )
-      })
-
-      it('should accept component when concentration is provided and name is missing', () => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            hazardous: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              components: [
-                {
-                  name: undefined,
-                  concentration: 30
-                }
-              ]
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      })
-
-      it('should accept component when name is provided and concentration is missing', () => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            hazardous: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              components: [
-                {
-                  name: 'Mercury',
-                  concentration: undefined
-                }
-              ]
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      })
-
-      it('should accept component when name and concentration are missing', () => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            hazardous: {
-              containsHazardous: true,
-              sourceOfComponents: validSourceOfComponents.CARRIER_PROVIDED,
-              components: [
-                {
-                  name: undefined,
-                  concentration: undefined
-                }
-              ]
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      })
-    })
-
-    describe('When waste does not contain hazardous properties', () => {
-      it('should accept submission without chemical/bio concentration', () => {
-        const result = validateHazardousWithComponents(
-          false,
-          undefined,
-          sourceOfComponentsNotProvided.NOT_PROVIDED
-        )
-        expect(result.error).toBeUndefined()
-      })
-
-      it('should reject when chemical/bio concentration is provided', () => {
-        const result = validateHazardousWithComponents(false, [
-          {
-            name: 'Mercury',
-            concentration: 30
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological components cannot be provided when no hazardous properties are indicated'
-        )
-      })
-
-      it('should reject when "Not Supplied" concentration is provided', () => {
-        const result = validateHazardousWithComponents(false, [
-          {
-            name: 'Mercury',
-            concentration: 'Not Supplied'
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological components cannot be provided when no hazardous properties are indicated'
-        )
-      })
-
-      it('should reject when blank concentration is provided', () => {
-        const result = validateHazardousWithComponents(false, [
-          {
-            name: 'Mercury',
-            concentration: ''
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological components cannot be provided when no hazardous properties are indicated'
-        )
-      })
-    })
-
-    describe('Multiple components validation', () => {
-      it('should accept multiple components with valid concentrations', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: 30
-          },
-          {
-            name: 'Lead',
-            concentration: 'Not Supplied'
-          },
-          {
-            name: 'Cadmium',
-            concentration: 15
-          }
-        ])
-        expect(result.error).toBeUndefined()
-      })
-
-      it('should reject when any component has invalid concentration', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: 30
-          },
-          {
-            name: 'Lead',
-            concentration: 'Invalid Value'
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological concentration must be a valid number or "Not Supplied"'
-        )
-      })
-
-      it('should reject when any component has negative concentration', () => {
-        const result = validateHazardousWithComponents(true, [
-          {
-            name: 'Mercury',
-            concentration: 30
-          },
-          {
-            name: 'Lead',
-            concentration: -5
-          }
-        ])
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toContain(
-          'Chemical or Biological concentration cannot be negative'
-        )
-      })
-    })
-  })
-
-  describe('Chemical or Biological Component Name Validation', () => {
-    // Helper function to validate hazardous waste with component names
-    const validateComponentName = (
-      containsHazardous,
-      components,
-      sourceOfComponents = sourceOfComponentsNotProvided.NOT_PROVIDED
-    ) => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          hazardous: {
-            containsHazardous,
-            sourceOfComponents,
-            ...(components && { components })
-          }
-        }
-      })
-      return receiveMovementRequestSchema.validate(payload)
-    }
-
-    it('should accept valid hazardous substance names when hazardous properties are present', () => {
-      const result = validateComponentName(
-        true,
-        [
-          {
-            name: 'Mercury',
-            concentration: 50
-          }
-        ],
-        sourceOfComponentsProvided.CARRIER_PROVIDED
-      )
-      expect(result.error).toBeUndefined()
-    })
-
-    it('should REJECT null as component name when hazardous properties are present', () => {
-      const result = validateComponentName(true, [
-        {
-          name: null,
-          concentration: 30
-        }
-      ])
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toContain(
-        'Chemical or Biological Component name must be an actual component name, not null'
-      )
-    })
-
-    it('should accept submission without components regardless of hazardous properties', () => {
-      // Test with hazardous=true
-      const resultHazardous = validateComponentName(true)
-      expect(resultHazardous.error).toBeUndefined()
-
-      // Test with hazardous=false
-      const resultNonHazardous = validateComponentName(false)
-      expect(resultNonHazardous.error).toBeUndefined()
-    })
-
-    it('should reject components when no hazardous properties are indicated', () => {
-      const result = validateComponentName(
-        false,
-        [
-          {
-            name: 'Mercury',
-            concentration: 25
-          }
-        ],
-        sourceOfComponentsProvided.CARRIER_PROVIDED
-      )
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toContain(
-        'Chemical or Biological components cannot be provided when no hazardous properties are indicated'
-      )
-    })
-  })
+  testPopsAndHazardousComponents('Hazardous')
 })

--- a/src/schemas/waste-pops.test.js
+++ b/src/schemas/waste-pops.test.js
@@ -391,7 +391,7 @@ describe('Receipt Schema Validation - POPs', () => {
       )
     })
 
-    it('should reject POPs when containsPops is true and concentration is a negatve number', () => {
+    it('should reject POPs when containsPops is true and concentration is a negative number', () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
           pops: {
@@ -471,7 +471,7 @@ describe('Receipt Schema Validation - POPs', () => {
     )
 
     it.each([undefined, null])(
-      'should reject POPs when containsPops is true and no components are provided: "%s"',
+      'should reject POPs when containsPops is true, sourceOfComponents is other than NOT_PROVIDED and no components are provided: "%s"',
       (value) => {
         const payload = createTestPayload({
           wasteItemOverrides: {
@@ -487,6 +487,23 @@ describe('Receipt Schema Validation - POPs', () => {
         expect(result.error.message).toBe(
           '"wasteItems[0].pops.components" is required when POPs are present'
         )
+      }
+    )
+
+    it.each([undefined, null])(
+      'should accept POPs when containsPops is true, sourceOfComponents is NOT_PROVIDED and no components are provided: "%s"',
+      (value) => {
+        const payload = createTestPayload({
+          wasteItemOverrides: {
+            pops: {
+              containsPops: true,
+              sourceOfComponents: 'NOT_PROVIDED',
+              components: value
+            }
+          }
+        })
+        const result = receiveMovementRequestSchema.validate(payload)
+        expect(result.error).toBeUndefined()
       }
     )
 

--- a/src/schemas/waste-pops.test.js
+++ b/src/schemas/waste-pops.test.js
@@ -1,10 +1,7 @@
 import { receiveMovementRequestSchema } from './receipt.js'
 import { createTestPayload } from './test-helpers/waste-test-helpers.js'
 import { isValidPopName, validPopNames } from '../common/constants/pop-names.js'
-import {
-  sourceOfComponentsProvided,
-  validSourceOfComponents
-} from '../common/constants/source-of-components.js'
+import { testPopsAndHazardousComponents } from './test-helpers/pops-and-hazardous-components-test-helpers.js'
 
 describe('Receipt Schema Validation - POPs', () => {
   describe('POPs Indicator Validation', () => {
@@ -56,469 +53,52 @@ describe('Receipt Schema Validation - POPs', () => {
       const result = receiveMovementRequestSchema.validate(payload)
       expect(result.error).toBeDefined()
       expect(result.error.message).toBe(
-        'Does the waste contain persistent organic pollutants (POPs)? is required'
+        '"wasteItems[0].pops.containsPops" is required'
       )
     })
   })
 
-  describe('POP validation', () => {
-    for (const containsPopsValue of [true, false]) {
-      /*
-       * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
-       * 1	    FALSE			          NOT_PROVIDED		                        []					                              ACCEPT
-       * 6	    FALSE			          Other (e.g GUIDANCE, OWN TESTING etc)   []                                        ACCEPT
-       * 11     TRUE                NOT_PROVIDED                            []                                        ACCEPT
-       * 16     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   []                                        WARNING
-       */
-      it.each(Object.values(validSourceOfComponents))(
-        `should accept POPs when components is [], containsPops is ${containsPopsValue} and sourceOfComponents is %s`,
-        (value) => {
-          const payload = createTestPayload({
-            wasteItemOverrides: {
-              pops: {
-                containsPops: containsPopsValue,
-                sourceOfComponents: value,
-                components: []
-              }
-            }
-          })
-          const result = receiveMovementRequestSchema.validate(payload)
-          expect(result.error).toBeUndefined()
-        }
-      )
+  testPopsAndHazardousComponents('POPs')
 
-      /*
-       * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
-       * 2	    FALSE			          NOT_PROVIDED		                        [{}] 				                              REJECT
-       * 7      FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{}]                                      REJECT
-       * 12     TRUE                NOT_PROVIDED                            [{}]                                      REJECT
-       * 17     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{}]                                      REJECT
-       */
-      it.each(Object.values(validSourceOfComponents))(
-        `should reject POPs when an empty component is provided, containsPops is ${containsPopsValue} and sourceOfComponents is %s`,
-        (value) => {
-          const payload = createTestPayload({
-            wasteItemOverrides: {
-              pops: {
-                containsPops: containsPopsValue,
-                sourceOfComponents: value,
-                components: [
-                  {
-                    name: 'Aldrin',
-                    concentration: 100
-                  },
-                  {}
-                ]
-              }
+  it('should reject POP name with an invalid value', () => {
+    const payload = createTestPayload({
+      wasteItemOverrides: {
+        pops: {
+          containsPops: true,
+          sourceOfComponents: 'CARRIER_PROVIDED',
+          components: [
+            {
+              name: 'Invalid POP Name',
+              concentration: 100
             }
-          })
-          const result = receiveMovementRequestSchema.validate(payload)
-          expect(result.error).toBeDefined()
-          expect(result.error.message).toBe(
-            '"wasteItems[0].pops.components[1].name" is required'
-          )
+          ]
         }
-      )
-    }
-
-    /*
-     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
-     * 3	    FALSE			          NOT_PROVIDED		                        [{ name: 'Aldrin' }]			                REJECT
-     * 8      FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin' }]                      REJECT
-     * 4	    FALSE			          NOT_PROVIDED		                        [{ concentration: 1.8 }]			            REJECT
-     * 5	    FALSE			          NOT_PROVIDED		                        [{ name: 'Aldrin', concentration: 1.8 }]  REJECT
-     * 9      FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{ concentration: 1.8 }]                  REJECT
-     * 10     FALSE               Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin', concentration: 1.8 }]  REJECT
-     */
-    it.each(Object.values(validSourceOfComponents))(
-      'should reject when components are provided, containsPops is false and sourceOfComponents is %s',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: false,
-              sourceOfComponents: value,
-              components: [
-                {
-                  name: 'Aldrin',
-                  concentration: 100
-                }
-              ]
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toBe(
-          'POP components must not be provided when POPs are not present'
-        )
       }
-    )
-
-    /*
-     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
-     * 13     TRUE                NOT_PROVIDED                            [{ name: 'Aldrin' }]                      REJECT
-     * 14     TRUE                NOT_PROVIDED                            [{ concentration: 1.8 }]                  REJECT
-     * 15     TRUE                NOT_PROVIDED                            [{ name: 'Aldrin', concentration: 1.8 }]  REJECT
-     */
-    it('should reject when components are provided, containsPops is true and sourceOfComponents is "NOT_PROVIDED', () => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true,
-            sourceOfComponents: 'NOT_PROVIDED',
-            components: [
-              {
-                name: 'Aldrin',
-                concentration: 100
-              }
-            ]
-          }
-        }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toBe(
-        'POP components must not be provided when the source of components is NOT_PROVIDED'
-      )
     })
+    const result = receiveMovementRequestSchema.validate(payload)
+    expect(result.error).toBeDefined()
+    expect(result.error.message).toBe(
+      `"wasteItems[0].pops.components[0].name" is not valid`
+    )
+  })
 
-    /*
-     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
-     * 20     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin', concentration: 1.8 }]  ACCEPT
-     */
-    it.each(Object.values(sourceOfComponentsProvided))(
-      'should accept when components are provided, containsPops is true and sourceOfComponents is %s',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: value,
-              components: [
-                {
-                  name: 'Aldrin',
-                  concentration: 100
-                }
-              ]
+  it.each(validPopNames)('should accept valid POP name: "%s"', (popName) => {
+    const payload = createTestPayload({
+      wasteItemOverrides: {
+        pops: {
+          containsPops: true,
+          sourceOfComponents: 'CARRIER_PROVIDED',
+          components: [
+            {
+              name: popName,
+              concentration: 100
             }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      }
-    )
-
-    /*
-     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
-     * 19     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{ concentration: 1.8 }]                  REJECT
-     */
-    it.each([undefined, null])(
-      'should reject when components are provided without a name, containsPops is true and sourceOfComponents is other than NOT_PROVIDED',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'CARRIER_PROVIDED',
-              components: [
-                {
-                  name: 'Aldrin',
-                  concentration: 100
-                },
-                {
-                  name: value,
-                  concentration: 30
-                }
-              ]
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toBe(
-          '"wasteItems[0].pops.components[1].name" is required'
-        )
-      }
-    )
-
-    /*
-     * item   contains<Haz/Pops>	sourceOfComponents	                    components			                          expected outcome
-     * 18     TRUE                Other (e.g GUIDANCE, OWN TESTING etc)   [{ name: 'Aldrin' }]                      WARNING
-     */
-    it.each([undefined, null])(
-      'should accept when components are provided without a concentration, containsPops is true and sourceOfComponents is other than NOT_PROVIDED',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'CARRIER_PROVIDED',
-              components: [
-                {
-                  name: 'Aldrin',
-                  concentration: 100
-                },
-                {
-                  name: 'Chlordane',
-                  concentration: value
-                }
-              ]
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      }
-    )
-
-    it('should reject invalid POP name: ""', () => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true,
-            sourceOfComponents: 'CARRIER_PROVIDED',
-            components: [
-              {
-                name: 'Aldrin',
-                concentration: 100
-              },
-              {
-                name: '',
-                concentration: 100
-              }
-            ]
-          }
+          ]
         }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toBe(
-        '"wasteItems[0].pops.components[1].name" is not allowed to be empty'
-      )
-    })
-
-    it('should reject POP name with an invalid value', () => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true,
-            sourceOfComponents: 'CARRIER_PROVIDED',
-            components: [
-              {
-                name: 'Invalid POP Name',
-                concentration: 100
-              }
-            ]
-          }
-        }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toBe(
-        '"wasteItems[0].pops.components[0].name" is not valid'
-      )
-    })
-
-    it.each(validPopNames)('should accept valid POP name: "%s"', (popName) => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true,
-            sourceOfComponents: 'CARRIER_PROVIDED',
-            components: [
-              {
-                name: popName,
-                concentration: 100
-              }
-            ]
-          }
-        }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeUndefined()
-    })
-
-    it.each([12.5, 9.12345678, 500, 0])(
-      'should accept valid POP concentration value: "%s"',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'CARRIER_PROVIDED',
-              components: [
-                {
-                  name: 'Aldrin',
-                  concentration: 100
-                },
-                {
-                  name: 'Aldrin',
-                  concentration: value
-                }
-              ]
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
       }
-    )
-
-    it('should reject POPs when containsPops is true and concentration is not a number', () => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true,
-            sourceOfComponents: 'OWN_TESTING',
-            components: [
-              {
-                name: 'Aldrin',
-                concentration: 100
-              },
-              {
-                name: 'Endosulfan',
-                concentration: 'ten'
-              }
-            ]
-          }
-        }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toBe(
-        '"wasteItems[0].pops.components[1].concentration" must be a valid number'
-      )
     })
-
-    it('should reject POPs when containsPops is true and concentration is a negative number', () => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true,
-            sourceOfComponents: 'OWN_TESTING',
-            components: [
-              {
-                name: 'Aldrin',
-                concentration: 100
-              },
-              {
-                name: 'Endosulfan',
-                concentration: -10
-              }
-            ]
-          }
-        }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toBe(
-        '"wasteItems[0].pops.components[1].concentration" concentration cannot be negative'
-      )
-    })
-
-    it('should reject POPs when containsPops is true and sourceOfComponents is missing', () => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true
-          }
-        }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toBe(
-        'Source of POP components is required when POPs are present'
-      )
-    })
-
-    it('should reject POPs when containsPops is true and sourceOfComponents is invalid', () => {
-      const payload = createTestPayload({
-        wasteItemOverrides: {
-          pops: {
-            containsPops: true,
-            sourceOfComponents: 'INVALID_SOURCE',
-            components: [
-              {
-                name: 'Aldrin',
-                concentration: 100
-              }
-            ]
-          }
-        }
-      })
-      const result = receiveMovementRequestSchema.validate(payload)
-      expect(result.error).toBeDefined()
-      expect(result.error.message).toBe(
-        `"wasteItems[0].pops.sourceOfComponents" must be one of [${Object.values(validSourceOfComponents).join(', ')}]`
-      )
-    })
-
-    it.each([undefined, null])(
-      'should accept POPs when containsPops is false and no components are provided: "%s"',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: false,
-              components: value
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      }
-    )
-
-    it.each([undefined, null])(
-      'should reject POPs when containsPops is true, sourceOfComponents is other than NOT_PROVIDED and no components are provided: "%s"',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'CARRIER_PROVIDED',
-              components: value
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeDefined()
-        expect(result.error.message).toBe(
-          '"wasteItems[0].pops.components" is required when POPs are present'
-        )
-      }
-    )
-
-    it.each([undefined, null])(
-      'should accept POPs when containsPops is true, sourceOfComponents is NOT_PROVIDED and no components are provided: "%s"',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: {
-              containsPops: true,
-              sourceOfComponents: 'NOT_PROVIDED',
-              components: value
-            }
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      }
-    )
-
-    it.each([undefined, null])(
-      'should accepts POPs when pops is not provided: "%s"',
-      (value) => {
-        const payload = createTestPayload({
-          wasteItemOverrides: {
-            pops: value
-          }
-        })
-        const result = receiveMovementRequestSchema.validate(payload)
-        expect(result.error).toBeUndefined()
-      }
-    )
+    const result = receiveMovementRequestSchema.validate(payload)
+    expect(result.error).toBeUndefined()
   })
 
   describe('isValidPopName function unit tests', () => {

--- a/src/schemas/waste.js
+++ b/src/schemas/waste.js
@@ -66,10 +66,6 @@ const popsSchema = Joi.object({
         'any.required':
           'Source of POP components is required when POPs are present'
       })
-      // otherwise: Joi.forbidden().messages({
-      //   'any.unknown':
-      //     'Source of POP components can only be provided when POPs are present'
-      // })
     }),
   components: Joi.array()
     .items(
@@ -114,8 +110,12 @@ const popsSchema = Joi.object({
     .empty(null)
     .when('containsPops', {
       is: true,
-      then: Joi.required().messages({
-        'any.required': '{{ #label }} is required when POPs are present'
+      then: Joi.when('sourceOfComponents', {
+        is: 'NOT_PROVIDED',
+        then: Joi.optional(),
+        otherwise: Joi.required().messages({
+          'any.required': '{{ #label }} is required when POPs are present'
+        })
       })
     })
 })


### PR DESCRIPTION
Ticket [DWT-624](https://eaflood.atlassian.net/browse/DWT-624)

Changes:
- Update Hazardous validation to match POPs
- Update POPs components unit tests to be re-useable and implement for Hazardous
- Update POPs warnings logic and unit tests to be re-useable and implement for Hazardous 