### PR TITLE
DWT-576 Update Carrier Registration Number validation

### DIFF
--- a/src/common/constants/regexes.js
+++ b/src/common/constants/regexes.js
@@ -1,0 +1,22 @@
+// RegEx per Gov UK recommendation: https://assets.publishing.service.gov.uk/media/5a7f3ff4ed915d74e33f5438/Bulk_Data_Transfer_-_additional_validation_valid_from_12_November_2015.pdf
+export const UK_POSTCODE_REGEX =
+  /^((GIR 0A{2})|((([A-Z]\d{1,2})|(([A-Z][A-HJ-Y]\d{1,2})|(([A-Z]\d[A-Z])|([A-Z][A-HJ-Y]\d?[A-Z])))) \d[A-Z]{2}))$/i // NOSONAR
+
+// Ireland Eircode regex (routing key + unique identifier)
+// Reference: https://www.eircode.ie
+export const IRL_POSTCODE_REGEX =
+  /^(?:D6W|[AC-FHKNPRTV-Y]\d{2}) ?[0-9AC-FHKNPRTV-Y]{4}$/i
+
+/*
+ * Carrier Registration Numbers
+ * See src/test/data/carrier-registration-numbers.js for examples
+ */
+export const ENGLAND_CARRIER_REGISTRATION_NUMBER_REGEX = /^CBD[LU]\d{3,}$/i
+
+export const SEPA_CARRIER_REGISTRATION_NUMBER_REGEX =
+  /^((WCR\/R\/\d{7})|((SCO|SEA|SNO|SWE|WCR)\/\d{6}))$/i
+
+export const NRU_CARRIER_REGISTRATION_NUMBER_REGEX =
+  ENGLAND_CARRIER_REGISTRATION_NUMBER_REGEX
+
+export const NI_CARRIER_REGISTRATION_NUMBER_REGEX = /^ROC\W*[UL]T\W*\d{1,5}$/i

--- a/src/schemas/carrier.test.js
+++ b/src/schemas/carrier.test.js
@@ -57,23 +57,35 @@ describe('Carrier Registration Validation', () => {
         expect(error).toBeUndefined()
       }
     )
-  })
 
-  describe('Scenario: Invalid submissions', () => {
-    it.each([null, undefined])(
-      'rejects submission with a missing carrier registration number: "%s"',
+    it.each([null, ''])(
+      'accepts submission when registrationNumber is "%s" and reasonForNoRegistrationNumber is provided',
       (value) => {
         const carrier = {
           registrationNumber: value,
+          reasonForNoRegistrationNumber: 'Not provided',
           organisationName: 'Test Carrier',
           meansOfTransport: MEANS_OF_TRANSPORT[1]
         }
 
         const { error } = validate(carrier)
-        expect(error).toBeDefined()
-        expect(error.message).toBe('"carrier.registrationNumber" is required')
+        expect(error).toBeUndefined()
       }
     )
+  })
+
+  describe('Scenario: Invalid submissions', () => {
+    it('rejects submission with a missing carrier registration number', () => {
+      const carrier = {
+        registrationNumber: undefined,
+        organisationName: 'Test Carrier',
+        meansOfTransport: MEANS_OF_TRANSPORT[1]
+      }
+
+      const { error } = validate(carrier)
+      expect(error).toBeDefined()
+      expect(error.message).toBe('"carrier.registrationNumber" is required')
+    })
 
     it.each(invalidCarrierRegistrationNumbers)(
       'rejects submission with an invalid carrier registration number: "%s"',
@@ -104,7 +116,7 @@ describe('Carrier Registration Validation', () => {
       const { error } = validate(carrier)
       expect(error).toBeDefined()
       expect(error.message).toBe(
-        'Reason for no registration number should only be provided when registration number is not provided'
+        'carrier.reasonForNoRegistrationNumber should only be provided when carrier.registrationNumber is not provided'
       )
     })
 
@@ -118,6 +130,64 @@ describe('Carrier Registration Validation', () => {
       const { error } = validate(carrier)
       expect(error).toBeDefined()
       expect(error.message).toBe('"carrier.meansOfTransport" is required')
+    })
+
+    it.each([
+      {
+        registrationNumber: null,
+        reasonForNoRegistrationNumber: null,
+        description:
+          'null registrationNumber and null reasonForNoRegistrationNumber'
+      },
+      {
+        registrationNumber: null,
+        reasonForNoRegistrationNumber: '',
+        description:
+          'null registrationNumber and empty reasonForNoRegistrationNumber'
+      },
+      {
+        registrationNumber: '',
+        reasonForNoRegistrationNumber: '',
+        description:
+          'empty registrationNumber and empty reasonForNoRegistrationNumber'
+      },
+      {
+        registrationNumber: '',
+        reasonForNoRegistrationNumber: null,
+        description:
+          'empty registrationNumber and null reasonForNoRegistrationNumber'
+      }
+    ])(
+      'rejects submission with $description',
+      ({ registrationNumber, reasonForNoRegistrationNumber }) => {
+        const carrier = {
+          registrationNumber,
+          reasonForNoRegistrationNumber,
+          organisationName: 'Test Carrier',
+          meansOfTransport: MEANS_OF_TRANSPORT[1]
+        }
+
+        const { error } = validate(carrier)
+        expect(error).toBeDefined()
+        expect(error.message).toBe(
+          'Either carrier.registrationNumber or carrier.reasonForNoRegistrationNumber is required'
+        )
+      }
+    )
+
+    it('rejects submission when both registrationNumber and reasonForNoRegistrationNumber are provided', () => {
+      const carrier = {
+        registrationNumber: validCarrierRegistrationNumbers[0],
+        reasonForNoRegistrationNumber: 'Not provided',
+        organisationName: 'Test Carrier',
+        meansOfTransport: MEANS_OF_TRANSPORT[1]
+      }
+
+      const { error } = validate(carrier)
+      expect(error).toBeDefined()
+      expect(error.message).toBe(
+        'carrier.reasonForNoRegistrationNumber should only be provided when carrier.registrationNumber is not provided'
+      )
     })
   })
 
@@ -213,7 +283,7 @@ describe('Carrier Registration Validation', () => {
       const { error } = validate(carrier)
       expect(error).toBeDefined()
       expect(error.message).toBe(
-        'If carrier.meansOfTransport is "Road" then carrier.vehicleRegistration is required.'
+        'If carrier.meansOfTransport is "Road" then carrier.vehicleRegistration is required'
       )
     })
 
@@ -245,7 +315,7 @@ describe('Carrier Registration Validation', () => {
         const { error } = validate(carrier)
         expect(error).toBeDefined()
         expect(error.message).toBe(
-          'If carrier.meansOfTransport is not "Road" then carrier.vehicleRegistration is not applicable.'
+          'If carrier.meansOfTransport is not "Road" then carrier.vehicleRegistration is not applicable'
         )
       }
     )

--- a/src/test/data/carrier-registration-numbers.js
+++ b/src/test/data/carrier-registration-numbers.js
@@ -1,0 +1,66 @@
+export const validEnglandCarrierRegistrationNumbers = [
+  'CBDL999',
+  'CBDL9999',
+  'CBDL99999',
+  'CBDL999999',
+  'CBDL99999999999999999999',
+  'CBDU999',
+  'CBDU9999',
+  'CBDU99999',
+  'CBDU99999999999999999999'
+]
+
+export const validSepaCarrierRegistrationNumbers = [
+  'WCR/R/9999999',
+  'SCO/999999',
+  'SEA/999999',
+  'SNO/999999',
+  'SWE/999999',
+  'WCR/999999'
+]
+
+export const validNrwCarrierRegistrationNumbers =
+  validEnglandCarrierRegistrationNumbers
+
+export const validNiCarrierRegistrationNumbers = [
+  'ROC UT 9',
+  'ROC UT 99',
+  'ROC UT 999',
+  'ROC UT 9999',
+  'ROC UT 99999',
+  'ROC LT 9',
+  'ROC LT 99',
+  'ROC LT 999',
+  'ROC LT 9999',
+  'ROC LT 99999'
+]
+
+export const validCarrierRegistrationNumbers = [
+  ...new Set([
+    ...validEnglandCarrierRegistrationNumbers,
+    ...validSepaCarrierRegistrationNumbers,
+    ...validNrwCarrierRegistrationNumbers,
+    ...validNiCarrierRegistrationNumbers
+  ])
+]
+
+export const invalidCarrierRegistrationNumbers = [
+  'CBD999',
+  'CBDT999',
+  'CBDL99',
+  'CBDU99',
+  'WCR/R/999999',
+  'WCR/R/99999999',
+  'SCO/99999',
+  'SCO/9999999',
+  'SC/999999',
+  'SCD/999999',
+  'ROC U 9',
+  'ROC L 9',
+  'ROC DT 9',
+  'ROC UT 999999',
+  'ROC LT 999999',
+  '',
+  '   ',
+  ' CBDL999 '
+]

--- a/src/test/data/carrier-registration-numbers.js
+++ b/src/test/data/carrier-registration-numbers.js
@@ -60,7 +60,6 @@ export const invalidCarrierRegistrationNumbers = [
   'ROC DT 9',
   'ROC UT 999999',
   'ROC LT 999999',
-  '',
   '   ',
   ' CBDL999 '
 ]


### PR DESCRIPTION
Ticket [DWT-576](https://eaflood.atlassian.net/browse/DWT-576)

Changes:
- Add Carrier Registration Number regex validation
- Add Carrier Registration Number unit tests with test data in `src/test/data/carrier-registration-numbers.js`
- Move regexes to a separate file in `src/common/constants/regexes.js`


[DWT-576]: https://eaflood.atlassian.net/browse/DWT-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ