### PR TITLE
DWT-630 Add integer constraints to number properties

### DIFF
--- a/src/routes/disposal-recovery-codes.test.js
+++ b/src/routes/disposal-recovery-codes.test.js
@@ -60,7 +60,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
                 code,
                 weight: {
                   metric: 'Tonnes',
-                  amount: 0.1,
+                  amount: 1,
                   isEstimate: false
                 }
               }
@@ -79,7 +79,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
               code: 'R1',
               weight: {
                 metric: 'Tonnes',
-                amount: 0.1,
+                amount: 1,
                 isEstimate: false
               }
             },
@@ -87,7 +87,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
               code: 'D10',
               weight: {
                 metric: 'Tonnes',
-                amount: 0.0505,
+                amount: 2,
                 isEstimate: false
               }
             },
@@ -95,7 +95,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
               code: 'R3',
               weight: {
                 metric: 'Tonnes',
-                amount: 0.02,
+                amount: 3,
                 isEstimate: false
               }
             }
@@ -118,7 +118,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
                 code,
                 weight: {
                   metric: 'Tonnes',
-                  amount: 0.1,
+                  amount: 1,
                   isEstimate: false
                 }
               }
@@ -193,7 +193,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
               code: 'R1',
               weight: {
                 metric: 'Tonnes',
-                amount: 0.1,
+                amount: 1,
                 isEstimate: false
               }
             }
@@ -237,7 +237,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
               code: 'R3',
               weight: {
                 metric: 'Tonnes',
-                amount: 0.02,
+                amount: 2,
                 isEstimate: false
               }
             },
@@ -245,7 +245,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
               code: 'D5',
               weight: {
                 metric: 'Tonnes',
-                amount: 0.03,
+                amount: 3,
                 isEstimate: false
               }
             }
@@ -286,7 +286,7 @@ describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
               code: 'R1',
               weight: {
                 metric: 'Tonnes',
-                amount: 0.1,
+                amount: 1,
                 isEstimate: false
               }
             }

--- a/src/schemas/receipt.js
+++ b/src/schemas/receipt.js
@@ -109,7 +109,10 @@ const receiverSchema = Joi.object({
   phoneNumber: Joi.string(),
   authorisationNumbers: Joi.array().items(Joi.string()).min(1).required(),
   regulatoryPositionStatements: Joi.array().items(
-    Joi.number().integer().positive()
+    Joi.number().integer().min(0).greater(0).messages({
+      'number.min': '{{ #label }} must be greater than 0',
+      'number.greater': '{{ #label }} must be greater than 0'
+    })
   )
 }).label('Receiver')
 

--- a/src/schemas/receipt.js
+++ b/src/schemas/receipt.js
@@ -109,9 +109,10 @@ const receiverSchema = Joi.object({
   phoneNumber: Joi.string(),
   authorisationNumbers: Joi.array().items(Joi.string()).min(1).required(),
   regulatoryPositionStatements: Joi.array().items(
-    Joi.number().integer().min(0).greater(0).messages({
+    Joi.number().integer().strict().min(0).greater(0).messages({
       'number.min': '{{ #label }} must be greater than 0',
-      'number.greater': '{{ #label }} must be greater than 0'
+      'number.greater': '{{ #label }} must be greater than 0',
+      'number.integer': '{{ #label }} must be an integer'
     })
   )
 }).label('Receiver')

--- a/src/schemas/rps.test.js
+++ b/src/schemas/rps.test.js
@@ -152,7 +152,7 @@ describe('Regulatory Position Statement (RPS) Validation', () => {
 
       const { error } = validate(receiver, receipt)
       expect(error).toBeDefined()
-      expect(error.message).toContain('must be a positive number')
+      expect(error.message).toContain('must be greater than 0')
     })
 
     it('rejects zero', () => {
@@ -168,7 +168,7 @@ describe('Regulatory Position Statement (RPS) Validation', () => {
 
       const { error } = validate(receiver, receipt)
       expect(error).toBeDefined()
-      expect(error.message).toContain('must be a positive number')
+      expect(error.message).toContain('must be greater than 0')
     })
 
     it('rejects decimal numbers', () => {

--- a/src/schemas/waste-containers.test.js
+++ b/src/schemas/waste-containers.test.js
@@ -16,13 +16,25 @@ describe('Receipt Schema Validation - Containers', () => {
       )
     })
 
-    it('should accept a positive number', () => {
+    it('should accept a positive integer', () => {
       const payload = createTestPayload({
-        wasteItemOverrides: { numberOfContainers: 0.1 }
+        wasteItemOverrides: { numberOfContainers: 1 }
       })
       const result = receiveMovementRequestSchema.validate(payload)
 
       expect(result.error).toBeUndefined()
+    })
+
+    it('should reject a decimal number', () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: { numberOfContainers: 1.5 }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toContain(
+        '"wasteItems[0].numberOfContainers" must be an integer'
+      )
     })
 
     it('should accept zero', () => {
@@ -36,7 +48,7 @@ describe('Receipt Schema Validation - Containers', () => {
 
     it('should reject a negative integer', () => {
       const payload = createTestPayload({
-        wasteItemOverrides: { numberOfContainers: -0.1 }
+        wasteItemOverrides: { numberOfContainers: -1 }
       })
       const result = receiveMovementRequestSchema.validate(payload)
 

--- a/src/schemas/waste.js
+++ b/src/schemas/waste.js
@@ -60,11 +60,12 @@ const sourceOfComponentsSchema = (fieldName) =>
     })
 
 const concentrationSchema = () =>
-  Joi.number().strict().min(0).greater(0).allow(null).messages({
+  Joi.number().strict().integer().min(0).greater(0).allow(null).messages({
     'any.required': ANY_REQUIRED_ERROR_MESSAGE,
     'number.base': '{{ #label }} must be a valid number',
     'number.min': '{{ #label }} concentration must be greater than 0',
-    'number.greater': '{{ #label }} concentration must be greater than 0'
+    'number.greater': '{{ #label }} concentration must be greater than 0',
+    'number.integer': '{{ #label }} concentration must be an integer'
   })
 
 const popsSchema = Joi.object({
@@ -224,7 +225,7 @@ export const wasteItemsSchema = Joi.object({
   physicalForm: Joi.string()
     .valid('Gas', 'Liquid', 'Solid', 'Powder', 'Sludge', 'Mixed')
     .required(),
-  numberOfContainers: Joi.number().required().min(0),
+  numberOfContainers: Joi.number().strict().integer().required().min(0),
   typeOfContainers: Joi.string()
     .required()
     .custom(validateContainerType, 'Container type validation')

--- a/src/schemas/waste.js
+++ b/src/schemas/waste.js
@@ -8,7 +8,6 @@ import { DISPOSAL_OR_RECOVERY_CODES } from '../common/constants/treatment-codes.
 import { validSourceOfComponents } from '../common/constants/source-of-components.js'
 
 const MAX_EWC_CODES_COUNT = 5
-const CUSTOM_ERROR_TYPE = 'any.custom'
 const ANY_REQUIRED_ERROR_MESSAGE = '{{ #label }} is required'
 
 const disposalOrRecoveryCodeSchema = Joi.object({
@@ -61,27 +60,12 @@ const sourceOfComponentsSchema = (fieldName) =>
     })
 
 const concentrationSchema = () =>
-  Joi.custom((value, helpers) => {
-    if (typeof value === 'number') {
-      if (value < 0) {
-        return helpers.error('number.min')
-      }
-      return value
-    }
-
-    if (typeof value === 'string') {
-      return helpers.error(CUSTOM_ERROR_TYPE)
-    }
-
-    // Any other type is invalid
-    return helpers.error(CUSTOM_ERROR_TYPE)
+  Joi.number().strict().min(0).greater(0).allow(null).messages({
+    'any.required': ANY_REQUIRED_ERROR_MESSAGE,
+    'number.base': '{{ #label }} must be a valid number',
+    'number.min': '{{ #label }} concentration must be greater than 0',
+    'number.greater': '{{ #label }} concentration must be greater than 0'
   })
-    .allow(null)
-    .messages({
-      'any.required': ANY_REQUIRED_ERROR_MESSAGE,
-      'any.custom': '{{ #label }} must be a valid number',
-      'number.min': '{{ #label }} concentration cannot be negative'
-    })
 
 const popsSchema = Joi.object({
   containsPops: Joi.boolean().required().messages({

--- a/src/schemas/weight.js
+++ b/src/schemas/weight.js
@@ -2,7 +2,10 @@ import Joi from 'joi'
 
 export const weightSchema = Joi.object({
   metric: Joi.string().valid('Grams', 'Kilograms', 'Tonnes').required(),
-  amount: Joi.number().required().min(0),
+  amount: Joi.number().required().min(0).greater(0).messages({
+    'number.min': '{{ #label }} must be greater than 0',
+    'number.greater': '{{ #label }} must be greater than 0'
+  }),
   isEstimate: Joi.bool().required().messages({
     'any.required':
       'isEstimate is required. Please indicate whether the quantity is an estimate (true) or actual measurement (false)',

--- a/src/schemas/weight.js
+++ b/src/schemas/weight.js
@@ -2,10 +2,17 @@ import Joi from 'joi'
 
 export const weightSchema = Joi.object({
   metric: Joi.string().valid('Grams', 'Kilograms', 'Tonnes').required(),
-  amount: Joi.number().required().min(0).greater(0).messages({
-    'number.min': '{{ #label }} must be greater than 0',
-    'number.greater': '{{ #label }} must be greater than 0'
-  }),
+  amount: Joi.number()
+    .strict()
+    .integer()
+    .required()
+    .min(0)
+    .greater(0)
+    .messages({
+      'number.min': '{{ #label }} must be greater than 0',
+      'number.greater': '{{ #label }} must be greater than 0',
+      'number.integer': '{{ #label }} must be an integer'
+    }),
   isEstimate: Joi.bool().required().messages({
     'any.required':
       'isEstimate is required. Please indicate whether the quantity is an estimate (true) or actual measurement (false)',

--- a/src/schemas/weight.test.js
+++ b/src/schemas/weight.test.js
@@ -80,10 +80,13 @@ describe('Receipt Schema Validation - Weight', () => {
         expect(result.error).toBeUndefined()
       })
 
-      it('should accept zero', () => {
+      it('should reject zero', () => {
         const result = validateWithWeightOverrides({ amount: 0 })
 
-        expect(result.error).toBeUndefined()
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toContain(
+          '"wasteItems[0].weight.amount" must be greater than 0'
+        )
       })
 
       it('should reject a negative integer', () => {
@@ -91,7 +94,7 @@ describe('Receipt Schema Validation - Weight', () => {
 
         expect(result.error).toBeDefined()
         expect(result.error.message).toContain(
-          '"wasteItems[0].weight.amount" must be greater than or equal to 0'
+          '"wasteItems[0].weight.amount" must be greater than 0'
         )
       })
     })
@@ -184,10 +187,13 @@ describe('Receipt Schema Validation - Weight', () => {
         expect(result.error).toBeUndefined()
       })
 
-      it('should accept zero', () => {
+      it('should reject zero', () => {
         const result = validateWithReceiptWeightOverrides({ amount: 0 })
 
-        expect(result.error).toBeUndefined()
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toContain(
+          '"wasteItems[0].disposalOrRecoveryCodes[0].weight.amount" must be greater than 0'
+        )
       })
 
       it('should reject a negative integer', () => {
@@ -195,7 +201,7 @@ describe('Receipt Schema Validation - Weight', () => {
 
         expect(result.error).toBeDefined()
         expect(result.error.message).toContain(
-          '"wasteItems[0].disposalOrRecoveryCodes[0].weight.amount" must be greater than or equal to 0'
+          '"wasteItems[0].disposalOrRecoveryCodes[0].weight.amount" must be greater than 0'
         )
       })
     })

--- a/src/schemas/weight.test.js
+++ b/src/schemas/weight.test.js
@@ -74,10 +74,19 @@ describe('Receipt Schema Validation - Weight', () => {
         )
       })
 
-      it('should accept a positive number', () => {
-        const result = validateWithWeightOverrides({ amount: 0.1 })
+      it('should accept a positive integer', () => {
+        const result = validateWithWeightOverrides({ amount: 1 })
 
         expect(result.error).toBeUndefined()
+      })
+
+      it('should reject a decimal amount', () => {
+        const result = validateWithWeightOverrides({ amount: 1.5 })
+
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toContain(
+          '"wasteItems[0].weight.amount" must be an integer'
+        )
       })
 
       it('should reject zero', () => {
@@ -90,7 +99,7 @@ describe('Receipt Schema Validation - Weight', () => {
       })
 
       it('should reject a negative integer', () => {
-        const result = validateWithWeightOverrides({ amount: -0.1 })
+        const result = validateWithWeightOverrides({ amount: -1 })
 
         expect(result.error).toBeDefined()
         expect(result.error.message).toContain(
@@ -181,10 +190,19 @@ describe('Receipt Schema Validation - Weight', () => {
         )
       })
 
-      it('should accept a positive number', () => {
-        const result = validateWithReceiptWeightOverrides({ amount: 0.1 })
+      it('should accept a positive integer', () => {
+        const result = validateWithReceiptWeightOverrides({ amount: 1 })
 
         expect(result.error).toBeUndefined()
+      })
+
+      it('should reject a decimal amount', () => {
+        const result = validateWithReceiptWeightOverrides({ amount: 1.5 })
+
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toContain(
+          '"wasteItems[0].disposalOrRecoveryCodes[0].weight.amount" must be an integer'
+        )
       })
 
       it('should reject zero', () => {
@@ -197,7 +215,7 @@ describe('Receipt Schema Validation - Weight', () => {
       })
 
       it('should reject a negative integer', () => {
-        const result = validateWithReceiptWeightOverrides({ amount: -0.1 })
+        const result = validateWithReceiptWeightOverrides({ amount: -1 })
 
         expect(result.error).toBeDefined()
         expect(result.error.message).toContain(

--- a/src/test/common/pop-and-hazardous-components/pops-and-hazardous-components-error-tests.js
+++ b/src/test/common/pop-and-hazardous-components/pops-and-hazardous-components-error-tests.js
@@ -258,8 +258,7 @@ export function popsAndHazardousComponentsErrorTests(popsOrHazardous) {
     it.each([
       TWELVE_POINT_FIVE_NUMBER,
       NINE_POINT_ONE_NUMBER,
-      FIVE_HUNDRED_NUMBER,
-      ZERO_NUMBER
+      FIVE_HUNDRED_NUMBER
     ])('should accept valid POP concentration value: "%s"', (value) => {
       const payload = createTestPayload({
         wasteItemOverrides: {
@@ -309,6 +308,32 @@ export function popsAndHazardousComponentsErrorTests(popsOrHazardous) {
       )
     })
 
+    it(`should reject components when ${containsPopsOrHazardousField} is true and concentration is zero`, () => {
+      const payload = createTestPayload({
+        wasteItemOverrides: {
+          [popsOrHazardousObjectProperty]: {
+            [containsPopsOrHazardousField]: true,
+            sourceOfComponents: 'OWN_TESTING',
+            components: [
+              {
+                name: 'Aldrin',
+                concentration: 100
+              },
+              {
+                name: 'Endosulfan',
+                concentration: ZERO_NUMBER
+              }
+            ]
+          }
+        }
+      })
+      const result = receiveMovementRequestSchema.validate(payload)
+      expect(result.error).toBeDefined()
+      expect(result.error.message).toBe(
+        `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].concentration" concentration must be greater than 0`
+      )
+    })
+
     it(`should reject components when ${containsPopsOrHazardousField} is true and concentration is a negative number`, () => {
       const payload = createTestPayload({
         wasteItemOverrides: {
@@ -331,7 +356,7 @@ export function popsAndHazardousComponentsErrorTests(popsOrHazardous) {
       const result = receiveMovementRequestSchema.validate(payload)
       expect(result.error).toBeDefined()
       expect(result.error.message).toBe(
-        `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].concentration" concentration cannot be negative`
+        `"wasteItems[0].${popsOrHazardousObjectProperty}.components[1].concentration" concentration must be greater than 0`
       )
     })
 


### PR DESCRIPTION
### Description

Ticket [DWT-630](https://eaflood.atlassian.net/browse/DWT-630)

This pull request updates schema validations to enforce all numeric fields, such as concentrations and weights, to be strictly positive. Zero is no longer an acceptable value. Corresponding test cases and error messages have been adjusted to reflect this change.

[DWT-630]: https://eaflood.atlassian.net/browse/DWT-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ