### PR TITLE
DWT-577 Update BrokerOrDealers Registration Number Validation

### DIFF
--- a/src/schemas/broker.test.js
+++ b/src/schemas/broker.test.js
@@ -1,5 +1,6 @@
 import { receiveMovementRequestSchema } from './receipt.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
+import { carrierBrokerDealerRegistrationNumberErrorTests } from '../test/common/carrier-broker-dealer-regisration-number/carrier-broker-dealer-registration-number-error-tests.js'
 
 describe('BrokerOrDealer Validation', () => {
   const basePayload = createMovementRequest()
@@ -7,25 +8,45 @@ describe('BrokerOrDealer Validation', () => {
   const validate = (brokerOrDealer) =>
     receiveMovementRequestSchema.validate({ ...basePayload, brokerOrDealer })
 
-  describe('Broker Registration Number', () => {
-    it('accepts valid broker registration number', () => {
-      const broker = {
-        organisationName: 'Test Broker',
-        registrationNumber: 'CBDU123456'
-      }
+  carrierBrokerDealerRegistrationNumberErrorTests('BrokerOrDealer', {
+    organisationName: 'Test Broker',
+    registrationNumber: undefined
+  })
 
-      const { error } = validate(broker)
-      expect(error).toBeUndefined()
-    })
+  it('accepts submission with an undefined registration number', () => {
+    const broker = {
+      organisationName: 'Test Broker',
+      registrationNumber: undefined
+    }
 
-    it('accepts submission without broker registration number', () => {
-      const broker = {
-        organisationName: 'Test Broker'
-      }
+    const { error } = validate(broker)
+    expect(error).toBeUndefined()
+  })
 
-      const { error } = validate(broker)
-      expect(error).toBeUndefined()
-    })
+  it('rejects submission with a null registration number: "%s"', () => {
+    const broker = {
+      organisationName: 'Test Broker',
+      registrationNumber: null
+    }
+
+    const { error } = validate(broker)
+    expect(error).toBeDefined()
+    expect(error.message).toBe(
+      '"brokerOrDealer.registrationNumber" must be one of [string]'
+    )
+  })
+
+  it('rejects submission with an empty string registration number: "%s"', () => {
+    const broker = {
+      organisationName: 'Test Broker',
+      registrationNumber: ''
+    }
+
+    const { error } = validate(broker)
+    expect(error).toBeDefined()
+    expect(error.message).toBe(
+      '"brokerOrDealer.registrationNumber" must be in a valid England, SEPA, NRW or NI format'
+    )
   })
 
   it('accepts complete broker info with UK postcode, email and phone', () => {

--- a/src/schemas/carrier.test.js
+++ b/src/schemas/carrier.test.js
@@ -72,6 +72,21 @@ describe('Carrier Registration Validation', () => {
         expect(error).toBeUndefined()
       }
     )
+
+    it.each([null, ''])(
+      'accepts submission when registrationNumber is "%s" and reasonForNoRegistrationNumber is provided',
+      (value) => {
+        const carrier = {
+          registrationNumber: value,
+          reasonForNoRegistrationNumber: 'Not provided',
+          organisationName: 'Test Carrier',
+          meansOfTransport: MEANS_OF_TRANSPORT[1]
+        }
+
+        const { error } = validate(carrier)
+        expect(error).toBeUndefined()
+      }
+    )
   })
 
   describe('Scenario: Invalid submissions', () => {
@@ -86,23 +101,6 @@ describe('Carrier Registration Validation', () => {
       expect(error).toBeDefined()
       expect(error.message).toBe('"carrier.registrationNumber" is required')
     })
-  })
-
-  describe('Scenario: Invalid submissions', () => {
-    it.each([null, undefined])(
-      'rejects submission with a missing carrier registration number: "%s"',
-      (value) => {
-        const carrier = {
-          registrationNumber: value,
-          organisationName: 'Test Carrier',
-          meansOfTransport: MEANS_OF_TRANSPORT[1]
-        }
-
-        const { error } = validate(carrier)
-        expect(error).toBeDefined()
-        expect(error.message).toBe('"carrier.registrationNumber" is required')
-      }
-    )
 
     it.each(invalidCarrierRegistrationNumbers)(
       'rejects submission with an invalid carrier registration number: "%s"',

--- a/src/schemas/carrier.test.js
+++ b/src/schemas/carrier.test.js
@@ -86,6 +86,40 @@ describe('Carrier Registration Validation', () => {
       expect(error).toBeDefined()
       expect(error.message).toBe('"carrier.registrationNumber" is required')
     })
+  })
+
+  describe('Scenario: Invalid submissions', () => {
+    it.each([null, undefined])(
+      'rejects submission with a missing carrier registration number: "%s"',
+      (value) => {
+        const carrier = {
+          registrationNumber: value,
+          organisationName: 'Test Carrier',
+          meansOfTransport: MEANS_OF_TRANSPORT[1]
+        }
+
+        const { error } = validate(carrier)
+        expect(error).toBeDefined()
+        expect(error.message).toBe('"carrier.registrationNumber" is required')
+      }
+    )
+
+    it.each(invalidCarrierRegistrationNumbers)(
+      'rejects submission with an invalid carrier registration number: "%s"',
+      (value) => {
+        const carrier = {
+          registrationNumber: value,
+          organisationName: 'Test Carrier',
+          meansOfTransport: MEANS_OF_TRANSPORT[1]
+        }
+
+        const { error } = validate(carrier)
+        expect(error).toBeDefined()
+        expect(error.message).toBe(
+          '"carrier.registrationNumber" must be in a valid England, SEPA, NRW or NI format'
+        )
+      }
+    )
 
     it.each(invalidCarrierRegistrationNumbers)(
       'rejects submission with an invalid carrier registration number: "%s"',

--- a/src/schemas/carrier.test.js
+++ b/src/schemas/carrier.test.js
@@ -1,10 +1,10 @@
 import { receiveMovementRequestSchema } from './receipt.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
 import { MEANS_OF_TRANSPORT } from '../common/constants/means-of-transport.js'
+import { carrierBrokerDealerRegistrationNumberErrorTests } from '../test/common/carrier-broker-dealer-regisration-number/carrier-broker-dealer-registration-number-error-tests.js'
 import {
   invalidCarrierRegistrationNumbers,
-  validCarrierRegistrationNumbers,
-  validNiCarrierRegistrationNumbers
+  validCarrierRegistrationNumbers
 } from '../test/data/carrier-registration-numbers.js'
 
 describe('Carrier Registration Validation', () => {
@@ -13,66 +13,13 @@ describe('Carrier Registration Validation', () => {
   const validate = (carrier) =>
     receiveMovementRequestSchema.validate({ ...basePayload, carrier })
 
+  carrierBrokerDealerRegistrationNumberErrorTests('Carrier', {
+    registrationNumber: undefined,
+    organisationName: 'Test Carrier',
+    meansOfTransport: MEANS_OF_TRANSPORT[1]
+  })
+
   describe('Scenario: Valid carrier registration number', () => {
-    it.each(validCarrierRegistrationNumbers)(
-      'accepts submission with valid carrier registration number: "%s"',
-      (value) => {
-        const carrier = {
-          registrationNumber: value,
-          organisationName: 'Test Carrier',
-          meansOfTransport: MEANS_OF_TRANSPORT[1]
-        }
-
-        const { error } = validate(carrier)
-        expect(error).toBeUndefined()
-      }
-    )
-
-    it.each(validCarrierRegistrationNumbers.map((v) => v.toLowerCase()))(
-      'accepts submission with lowercase carrier registration number: "%s"',
-      (value) => {
-        const carrier = {
-          registrationNumber: value,
-          organisationName: 'Test Carrier',
-          meansOfTransport: MEANS_OF_TRANSPORT[1]
-        }
-
-        const { error } = validate(carrier)
-        expect(error).toBeUndefined()
-      }
-    )
-
-    it.each(
-      validNiCarrierRegistrationNumbers.map((v) => v.replaceAll(' ', ''))
-    )(
-      'accepts submission with NI carrier registration number without spaces: "%s"',
-      (value) => {
-        const carrier = {
-          registrationNumber: value,
-          organisationName: 'Test Carrier',
-          meansOfTransport: MEANS_OF_TRANSPORT[1]
-        }
-
-        const { error } = validate(carrier)
-        expect(error).toBeUndefined()
-      }
-    )
-
-    it.each([null, ''])(
-      'accepts submission when registrationNumber is "%s" and reasonForNoRegistrationNumber is provided',
-      (value) => {
-        const carrier = {
-          registrationNumber: value,
-          reasonForNoRegistrationNumber: 'Not provided',
-          organisationName: 'Test Carrier',
-          meansOfTransport: MEANS_OF_TRANSPORT[1]
-        }
-
-        const { error } = validate(carrier)
-        expect(error).toBeUndefined()
-      }
-    )
-
     it.each([null, ''])(
       'accepts submission when registrationNumber is "%s" and reasonForNoRegistrationNumber is provided',
       (value) => {
@@ -101,23 +48,6 @@ describe('Carrier Registration Validation', () => {
       expect(error).toBeDefined()
       expect(error.message).toBe('"carrier.registrationNumber" is required')
     })
-
-    it.each(invalidCarrierRegistrationNumbers)(
-      'rejects submission with an invalid carrier registration number: "%s"',
-      (value) => {
-        const carrier = {
-          registrationNumber: value,
-          organisationName: 'Test Carrier',
-          meansOfTransport: MEANS_OF_TRANSPORT[1]
-        }
-
-        const { error } = validate(carrier)
-        expect(error).toBeDefined()
-        expect(error.message).toBe(
-          '"carrier.registrationNumber" must be in a valid England, SEPA, NRW or NI format'
-        )
-      }
-    )
 
     it.each(invalidCarrierRegistrationNumbers)(
       'rejects submission with an invalid carrier registration number: "%s"',

--- a/src/schemas/receipt.js
+++ b/src/schemas/receipt.js
@@ -41,19 +41,21 @@ const addressSchema = Joi.object({
     .required()
 })
 
+const carrierOrBrokerDealerRegistrationNumber = Joi.alternatives()
+  .try(
+    Joi.string().pattern(ENGLAND_CARRIER_REGISTRATION_NUMBER_REGEX),
+    Joi.string().pattern(SEPA_CARRIER_REGISTRATION_NUMBER_REGEX),
+    Joi.string().pattern(NRU_CARRIER_REGISTRATION_NUMBER_REGEX),
+    Joi.string().pattern(NI_CARRIER_REGISTRATION_NUMBER_REGEX)
+  )
+  .messages({
+    'alternatives.match':
+      '{{ #label }} must be in a valid England, SEPA, NRW or NI format'
+  })
+
 const carrierSchema = Joi.object({
-  registrationNumber: Joi.alternatives()
-    .try(
-      Joi.string().pattern(ENGLAND_CARRIER_REGISTRATION_NUMBER_REGEX),
-      Joi.string().pattern(SEPA_CARRIER_REGISTRATION_NUMBER_REGEX),
-      Joi.string().pattern(NRU_CARRIER_REGISTRATION_NUMBER_REGEX),
-      Joi.string().pattern(NI_CARRIER_REGISTRATION_NUMBER_REGEX)
-    )
+  registrationNumber: carrierOrBrokerDealerRegistrationNumber
     .allow(null, '')
-    .messages({
-      'alternatives.match':
-        '{{ #label }} must be in a valid England, SEPA, NRW or NI format'
-    })
     .required(),
   reasonForNoRegistrationNumber: Joi.string()
     .when('registrationNumber', {
@@ -117,7 +119,7 @@ const receiptSchema = Joi.object({
 const brokerOrDealerSchema = Joi.object({
   organisationName: Joi.string().required(),
   address: addressSchema,
-  registrationNumber: Joi.string(),
+  registrationNumber: carrierOrBrokerDealerRegistrationNumber,
   phoneNumber: Joi.string(),
   emailAddress: Joi.string().email()
 }).label('BrokerOrDealer')

--- a/src/test/common/carrier-broker-dealer-regisration-number/carrier-broker-dealer-registration-number-error-tests.js
+++ b/src/test/common/carrier-broker-dealer-regisration-number/carrier-broker-dealer-registration-number-error-tests.js
@@ -1,0 +1,86 @@
+import { receiveMovementRequestSchema } from '../../../schemas/receipt.js'
+import {
+  invalidCarrierRegistrationNumbers,
+  validCarrierRegistrationNumbers,
+  validNiCarrierRegistrationNumbers
+} from '../../data/carrier-registration-numbers.js'
+import { createMovementRequest } from '../../utils/createMovementRequest.js'
+
+const basePayload = createMovementRequest()
+const validate = (objectProperty, testPayload, registrationNumber) => {
+  return receiveMovementRequestSchema.validate({
+    ...basePayload,
+    [objectProperty]: {
+      ...testPayload,
+      registrationNumber
+    }
+  })
+}
+
+export function carrierBrokerDealerRegistrationNumberErrorTests(
+  carrierOrBrokerDealer,
+  testPayload
+) {
+  if (!['Carrier', 'BrokerOrDealer'].includes(carrierOrBrokerDealer)) {
+    throw new Error(
+      'Expecting popsOrHazardous to be one of: Carrier, BrokerOrDealer'
+    )
+  }
+
+  const carrierOrBrokerDealerObjectProperty = `${String(carrierOrBrokerDealer).charAt(0).toLowerCase()}${String(carrierOrBrokerDealer).slice(1)}`
+
+  describe(`${carrierOrBrokerDealer} Registration Number Validation`, () => {
+    it.each(validCarrierRegistrationNumbers)(
+      `accepts submission with valid ${carrierOrBrokerDealer} registration number: "%s"`,
+      (value) => {
+        const { error } = validate(
+          carrierOrBrokerDealerObjectProperty,
+          testPayload,
+          value
+        )
+        expect(error).toBeUndefined()
+      }
+    )
+
+    it.each(validCarrierRegistrationNumbers.map((v) => v.toLowerCase()))(
+      `accepts submission with lowercase ${carrierOrBrokerDealer} registration number: "%s"`,
+      (value) => {
+        const { error } = validate(
+          carrierOrBrokerDealerObjectProperty,
+          testPayload,
+          value
+        )
+        expect(error).toBeUndefined()
+      }
+    )
+
+    it.each(
+      validNiCarrierRegistrationNumbers.map((v) => v.replaceAll(' ', ''))
+    )(
+      `accepts submission with NI ${carrierOrBrokerDealer} registration number without spaces: "%s"`,
+      (value) => {
+        const { error } = validate(
+          carrierOrBrokerDealerObjectProperty,
+          testPayload,
+          value
+        )
+        expect(error).toBeUndefined()
+      }
+    )
+
+    it.each(invalidCarrierRegistrationNumbers)(
+      `rejects submission with an invalid ${carrierOrBrokerDealer} registration number: "%s"`,
+      (value) => {
+        const { error } = validate(
+          carrierOrBrokerDealerObjectProperty,
+          testPayload,
+          value
+        )
+        expect(error).toBeDefined()
+        expect(error.message).toBe(
+          `"${carrierOrBrokerDealerObjectProperty}.registrationNumber" must be in a valid England, SEPA, NRW or NI format`
+        )
+      }
+    )
+  })
+}


### PR DESCRIPTION
Ticket [DWT-577](https://eaflood.atlassian.net/browse/DWT-577)

The validation for the BrokerOrDealer Registration Number field is very similar to that of the Carrier Registration Number so this PR is largely making re-useable components from the Carrier Registration Number validation and unit tests and implementing those for the BrokerOrDealer Registration Number.

Changes:
- Update Carriers Registration Number validation be be a shared component `carrierOrBrokerDealerRegistrationNumber`
- Implement `carrierOrBrokerDealerRegistrationNumber` for the BrokerOrDealer Registration Number
- Update common unit tests for Carriers Registration Number to be shared unit tests
- Implement shared unit tests from Carriers registration Number for the BrokerOrDealer Registration Number
-  Add additional specific BrokerOrDealer unit tests

[DWT-577]: https://eaflood.atlassian.net/browse/DWT-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ