### PR TITLE
DWT-797 Update reasonForNoConsignmentCode validation

### DIFF
--- a/src/schemas/hazardous-waste-consignment.js
+++ b/src/schemas/hazardous-waste-consignment.js
@@ -78,8 +78,7 @@ export const reasonForNoConsignmentCodeSchema = Joi.custom((value, helpers) => {
 
   return value
 }).messages({
-  'any.only':
-    'Reason for no consignment note code must be one of: Non-Hazardous Waste Transfer | Carrier did not provide documentation | Local Authority Receipt',
+  'any.only': `{{ #label }} must be one of: ${NO_CONSIGNMENT_REASONS.join(', ')}`,
   'reasonForNoConsignmentCode.required':
     '{{ #label }} is required when wasteItems[*].ewcCodes contains a hazardous code and hazardousWasteConsignmentCode is not provided'
 })

--- a/src/schemas/hazardous-waste-consignment.js
+++ b/src/schemas/hazardous-waste-consignment.js
@@ -28,14 +28,15 @@ export function hasHazardousEwcCodes(payload) {
 
 export const hazardousWasteConsignmentCodeSchema = Joi.custom(
   (value, helpers) => {
-    const hasHazardous = hasHazardousEwcCodes(helpers.state.ancestors[0])
+    const payload = helpers.state.ancestors[0]
+    const hasHazardous = hasHazardousEwcCodes(payload)
 
     // If hazardous EWC codes are present, the field is required if missing (undefined or null)
     if (
       hasHazardous &&
       !value &&
-      !helpers.state.ancestors[0].reasonForNoConsignmentCode &&
-      helpers.state.ancestors[0].hazardousWasteConsignmentCode !== ''
+      !payload.reasonForNoConsignmentCode &&
+      payload.hazardousWasteConsignmentCode !== ''
     ) {
       return helpers.error('hazardousWasteConsignmentCode.required')
     }
@@ -58,20 +59,18 @@ export const hazardousWasteConsignmentCodeSchema = Joi.custom(
 })
 
 export const reasonForNoConsignmentCodeSchema = Joi.custom((value, helpers) => {
-  const hasHazardous = hasHazardousEwcCodes(helpers.state.ancestors[0])
+  const payload = helpers.state.ancestors[0]
+  const hasHazardous = hasHazardousEwcCodes(payload)
 
-  if (
-    hasHazardous &&
-    !helpers.state.ancestors[0].hazardousWasteConsignmentCode
-  ) {
+  if (hasHazardous && !payload.hazardousWasteConsignmentCode) {
     if (
-      helpers.state.ancestors[0].reasonForNoConsignmentCode !== '' &&
+      payload.reasonForNoConsignmentCode !== '' &&
       !NO_CONSIGNMENT_REASONS.includes(value)
     ) {
       return helpers.error('any.only')
     }
 
-    if (!helpers.state.ancestors[0].reasonForNoConsignmentCode) {
+    if (!payload.reasonForNoConsignmentCode) {
       return helpers.error('reasonForNoConsignmentCode.required')
     }
   }

--- a/src/schemas/hazardous-waste-consignment.js
+++ b/src/schemas/hazardous-waste-consignment.js
@@ -59,16 +59,27 @@ export const hazardousWasteConsignmentCodeSchema = Joi.custom(
 
 export const reasonForNoConsignmentCodeSchema = Joi.custom((value, helpers) => {
   const hasHazardous = hasHazardousEwcCodes(helpers.state.ancestors[0])
+
   if (
     hasHazardous &&
-    !helpers.state.ancestors[0].hazardousWasteConsignmentCode &&
-    helpers.state.ancestors[0].reasonForNoConsignmentCode !== '' &&
-    !NO_CONSIGNMENT_REASONS.includes(value)
+    !helpers.state.ancestors[0].hazardousWasteConsignmentCode
   ) {
-    return helpers.error('any.only')
+    if (
+      helpers.state.ancestors[0].reasonForNoConsignmentCode !== '' &&
+      !NO_CONSIGNMENT_REASONS.includes(value)
+    ) {
+      return helpers.error('any.only')
+    }
+
+    if (!helpers.state.ancestors[0].reasonForNoConsignmentCode) {
+      return helpers.error('reasonForNoConsignmentCode.required')
+    }
   }
+
   return value
 }).messages({
   'any.only':
-    'Reason for no consignment note code must be one of: Non-Hazardous Waste Transfer | Carrier did not provide documentation | Local Authority Receipt'
+    'Reason for no consignment note code must be one of: Non-Hazardous Waste Transfer | Carrier did not provide documentation | Local Authority Receipt',
+  'reasonForNoConsignmentCode.required':
+    '{{ #label }} is required when wasteItems[*].ewcCodes contains a hazardous code and hazardousWasteConsignmentCode is not provided'
 })

--- a/src/schemas/hazardous-waste-consignment.js
+++ b/src/schemas/hazardous-waste-consignment.js
@@ -63,15 +63,10 @@ export const reasonForNoConsignmentCodeSchema = Joi.custom((value, helpers) => {
   const hasHazardous = hasHazardousEwcCodes(payload)
 
   if (hasHazardous && !payload.hazardousWasteConsignmentCode) {
-    if (
-      payload.reasonForNoConsignmentCode !== '' &&
-      !NO_CONSIGNMENT_REASONS.includes(value)
-    ) {
-      return helpers.error('any.only')
-    }
-
     if (!payload.reasonForNoConsignmentCode) {
       return helpers.error('reasonForNoConsignmentCode.required')
+    } else if (!NO_CONSIGNMENT_REASONS.includes(value)) {
+      return helpers.error('any.only')
     }
   }
 

--- a/src/schemas/hazardous-waste-consignment.test.js
+++ b/src/schemas/hazardous-waste-consignment.test.js
@@ -1,6 +1,7 @@
 import { receiveMovementRequestSchema } from './receipt.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
 import { validContainerTypes } from '../common/constants/container-types.js'
+import { NO_CONSIGNMENT_REASONS } from './hazardous-waste-consignment.js'
 
 // Helper to build a base valid payload
 const buildBasePayload = () => ({
@@ -103,8 +104,8 @@ describe('Hazardous Waste Consignment Note Code rules', () => {
 
     const { error } = receiveMovementRequestSchema.validate(payload)
     expect(error).toBeDefined()
-    expect(error.message).toContain(
-      'Reason for no consignment note code must be one of: Non-Hazardous Waste Transfer | Carrier did not provide documentation | Local Authority Receipt'
+    expect(error.message).toBe(
+      `"reasonForNoConsignmentCode" must be one of: ${NO_CONSIGNMENT_REASONS.join(', ')}`
     )
   })
 

--- a/src/schemas/hazardous-waste-consignment.test.js
+++ b/src/schemas/hazardous-waste-consignment.test.js
@@ -1,8 +1,4 @@
 import { receiveMovementRequestSchema } from './receipt.js'
-import {
-  generateAllValidationWarnings,
-  VALIDATION_ERROR_TYPES
-} from '../common/helpers/validation-warnings.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
 import { validContainerTypes } from '../common/constants/container-types.js'
 
@@ -119,14 +115,9 @@ describe('Hazardous Waste Consignment Note Code rules', () => {
     payload.reasonForNoConsignmentCode = '' // blank
 
     const { error } = receiveMovementRequestSchema.validate(payload)
-    expect(error).toBeUndefined()
-
-    const warnings = generateAllValidationWarnings(payload)
-    expect(warnings).toContainEqual({
-      key: 'receipt.reasonForNoConsignmentCode',
-      errorType: VALIDATION_ERROR_TYPES.NOT_PROVIDED,
-      message:
-        'Reason for no Consignment Note Code is required when hazardous EWC codes are present'
-    })
+    expect(error).toBeDefined()
+    expect(error.message).toContain(
+      '"reasonForNoConsignmentCode" is required when wasteItems[*].ewcCodes contains a hazardous code and hazardousWasteConsignmentCode is not provided'
+    )
   })
 })


### PR DESCRIPTION
Ticket [DWT-797](https://eaflood.atlassian.net/browse/DWT-797)

Changes: 
- Update `reasonForNoConsignmentCode` to return an error rather than a warning if both `reasonForNoConsignmentCode` and `hazardousWasteConsignmentCode` are empty
- Update `reasonForNoConsignmentCode` erorr message to give the correct list of reasons and reference the schema field
- Refactor payload variable to try to make the `hazardousWasteConsignmentCode`/`reasonForNoConsignmentCode` schemas a bit more readable
- Refactor the `reasonForNoConsignmentCodeSchema` custom validation logic to try to make it a bit more readable