### PR TITLE
DWT-717 Add EWC Codes Reference Data GET Endpoint

### DIFF
--- a/src/handlers/reference-data/get-ewc-codes.js
+++ b/src/handlers/reference-data/get-ewc-codes.js
@@ -1,0 +1,34 @@
+import {
+  isValidHazardousEwcCode,
+  validEwcCodes
+} from '../../common/constants/ewc-codes.js'
+import { HTTP_STATUS } from '../../common/constants/http-status-codes.js'
+import { handleBackendResponse } from '../handle-backend-response.js'
+
+export const handleGetEwcCodes = async (request, h) => {
+  try {
+    console.debug('Auth Info:', request?.auth)
+
+    const response = {
+      statusCode: HTTP_STATUS.OK
+    }
+    const responseData = mapGetEwcCodesResponse()
+
+    return handleBackendResponse(response, h, () => responseData)
+  } catch (error) {
+    console.error('Error getting EWC codes:', error)
+    return h
+      .response({
+        statusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error: 'Internal Server Error',
+        message: 'Failed to get EWC codes'
+      })
+      .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}
+
+export const mapGetEwcCodesResponse = () =>
+  validEwcCodes.map((code) => ({
+    code,
+    isHazardous: isValidHazardousEwcCode(code)
+  }))

--- a/src/handlers/reference-data/get-ewc-codes.js
+++ b/src/handlers/reference-data/get-ewc-codes.js
@@ -5,10 +5,8 @@ import {
 import { HTTP_STATUS } from '../../common/constants/http-status-codes.js'
 import { handleBackendResponse } from '../handle-backend-response.js'
 
-export const handleGetEwcCodes = async (request, h) => {
+export const handleGetEwcCodes = async (_request, h) => {
   try {
-    console.debug('Auth Info:', request?.auth)
-
     const response = {
       statusCode: HTTP_STATUS.OK
     }

--- a/src/handlers/reference-data/get-ewc-codes.test.js
+++ b/src/handlers/reference-data/get-ewc-codes.test.js
@@ -1,5 +1,6 @@
 import { describe, jest } from '@jest/globals'
 import { handleGetEwcCodes, mapGetEwcCodesResponse } from './get-ewc-codes.js'
+import * as handler from '../handle-backend-response.js'
 
 describe('GET EWC Codes', () => {
   describe('Get EWC Codes Handler', () => {
@@ -25,7 +26,7 @@ describe('GET EWC Codes', () => {
     })
 
     it('should return 500 when request to get EWC codes fails', async () => {
-      jest.spyOn(console, 'debug').mockImplementation(() => {
+      jest.spyOn(handler, 'handleBackendResponse').mockImplementation(() => {
         throw new Error('Internal Server Error')
       })
 

--- a/src/handlers/reference-data/get-ewc-codes.test.js
+++ b/src/handlers/reference-data/get-ewc-codes.test.js
@@ -1,0 +1,83 @@
+import { describe, jest } from '@jest/globals'
+import { handleGetEwcCodes, mapGetEwcCodesResponse } from './get-ewc-codes.js'
+
+describe('GET EWC Codes', () => {
+  describe('Get EWC Codes Handler', () => {
+    const validPayload = mapGetEwcCodesResponse()
+    const request = {
+      auth: {
+        credentials: {
+          clientId: 'test-client-id'
+        }
+      },
+      payload: validPayload
+    }
+
+    it('should successfully get a list of EWC codes', async () => {
+      const h = {
+        response: jest.fn().mockReturnThis(),
+        code: jest.fn().mockReturnThis()
+      }
+
+      await handleGetEwcCodes(request, h)
+
+      expect(h.response).toHaveBeenCalledWith(validPayload)
+    })
+
+    it('should return 500 when request to get EWC codes fails', async () => {
+      jest.spyOn(console, 'debug').mockImplementation(() => {
+        throw new Error('Internal Server Error')
+      })
+
+      const h = {
+        response: jest.fn().mockReturnThis(),
+        code: jest.fn().mockReturnThis()
+      }
+
+      await handleGetEwcCodes(request, h)
+
+      expect(h.response).toHaveBeenCalledWith({
+        statusCode: 500,
+        error: 'Internal Server Error',
+        message: 'Failed to get EWC codes'
+      })
+      expect(h.code).toHaveBeenCalledWith(500)
+    })
+  })
+
+  // Sanity tests so we don't need to test the entire list of codes
+  describe('mapGetEwcCodesResponse', () => {
+    it('should map EWC codes to the correct format', () => {
+      const ewcCodesResponse = mapGetEwcCodesResponse()
+
+      expect(ewcCodesResponse[0]).toStrictEqual({
+        code: '010101',
+        isHazardous: false
+      })
+    })
+
+    it('should return the correct number of codes in total', () => {
+      const ewcCodesResponse = mapGetEwcCodesResponse()
+
+      expect(ewcCodesResponse.length).toBe(840)
+    })
+
+    it('should return the correct number of hazardous codes', () => {
+      const ewcCodesResponse = mapGetEwcCodesResponse()
+      const hazardousEwcCodes = ewcCodesResponse.filter(
+        ({ isHazardous }) => isHazardous
+      )
+
+      expect(hazardousEwcCodes.length).toBe(407)
+    })
+
+    it('should return the correct number of non-hazardous codes', () => {
+      const ewcCodesResponse = mapGetEwcCodesResponse()
+      const nonHazardousEwcCodes = ewcCodesResponse.filter(
+        ({ isHazardous }) => !isHazardous
+      )
+
+      expect(nonHazardousEwcCodes.length).toBe(433)
+    })
+  })
+})

--- a/src/integration-tests/reference-data/get-ewc-codes.integration-test.js
+++ b/src/integration-tests/reference-data/get-ewc-codes.integration-test.js
@@ -27,6 +27,7 @@ describe('GET EWC Codes', () => {
       }
     })
 
-    expect(response).toStrictEqual(expectedResponse)
+    expect(response.statusCode).toBe(200)
+    expect(response.result).toStrictEqual(expectedResponse)
   })
 })

--- a/src/integration-tests/reference-data/get-ewc-codes.integration-test.js
+++ b/src/integration-tests/reference-data/get-ewc-codes.integration-test.js
@@ -1,0 +1,32 @@
+import { createServer } from '../server.js'
+import { MongoClient } from 'mongodb'
+import { mapGetEwcCodesResponse } from '../../handlers/reference-data/get-ewc-codes.js'
+
+describe('GET EWC Codes', () => {
+  let server
+  let mongoConnection
+
+  beforeAll(async () => {
+    server = await createServer()
+    mongoConnection = await MongoClient.connect('mongodb://localhost:27017', {})
+  })
+
+  afterAll(async () => {
+    server.stop()
+    mongoConnection.close()
+  })
+
+  it('should get EWC codes', async () => {
+    const expectedResponse = mapGetEwcCodesResponse()
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/reference-data/ewc-codes',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+
+    expect(response).toStrictEqual(expectedResponse)
+  })
+})

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -1,13 +1,19 @@
 import { health } from '../routes/health.js'
 import { createReceiptMovement } from '../routes/create-receipt-movement.js'
 import { updateReceiptMovement } from '../routes/update-receipt-movement.js'
+import { getEwcCodes } from '../routes/reference-data/get-ewc-codes.js'
 
 const router = {
   plugin: {
     name: 'router',
     register: async (server, _options) => {
       // Register all routes
-      const routes = [health, createReceiptMovement, updateReceiptMovement]
+      const routes = [
+        health,
+        createReceiptMovement,
+        updateReceiptMovement,
+        getEwcCodes
+      ]
 
       // Register routes directly
       server.route(routes)

--- a/src/routes/reference-data/get-ewc-codes.js
+++ b/src/routes/reference-data/get-ewc-codes.js
@@ -1,0 +1,23 @@
+import { HTTP_STATUS } from '../../common/constants/http-status-codes.js'
+import { handleGetEwcCodes } from '../../handlers/reference-data/get-ewc-codes.js'
+
+const getEwcCodes = {
+  method: 'GET',
+  path: '/reference-data/ewc-codes',
+  options: {
+    tags: ['reference-data'],
+    description: 'Endpoint to be used to get a list of EWC codes.',
+    plugins: {
+      'hapi-swagger': {
+        responses: {
+          [HTTP_STATUS.OK]: {
+            description: 'The list of EWC codes has been returned.'
+          }
+        }
+      }
+    }
+  },
+  handler: handleGetEwcCodes
+}
+
+export { getEwcCodes }


### PR DESCRIPTION
Ticket [DWT-717](https://eaflood.atlassian.net/browse/DWT-717)

Changes:
- Added EWC codes reference data GET endpoint
- Added Integration tests (not tested as we're not running these right now)

I've not been able to test this new endpoint so we should probably get it into Test and check that it's working correctly before we add the other similar ones

[DWT-717]: https://eaflood.atlassian.net/browse/DWT-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ