### PR TITLE
DWT-719 Reference data for disposal-or-recovery-codes

### DIFF
--- a/src/handlers/reference-data/get-disposal-or-recovery-codes.js
+++ b/src/handlers/reference-data/get-disposal-or-recovery-codes.js
@@ -1,0 +1,28 @@
+import { DISPOSAL_OR_RECOVERY_CODES } from '../../common/constants/treatment-codes.js'
+import { HTTP_STATUS } from '../../common/constants/http-status-codes.js'
+import { handleBackendResponse } from '../handle-backend-response.js'
+
+export const handleGetDisposalOrRecoveryCodes = async (_request, h) => {
+  try {
+    const response = {
+      statusCode: HTTP_STATUS.OK
+    }
+    const responseData = mapGetDisposalOrRecoveryCodesResponse()
+
+    return handleBackendResponse(response, h, () => responseData)
+  } catch (error) {
+    console.error('Error getting disposal or recovery codes:', error)
+    return h
+      .response({
+        statusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error: 'Internal Server Error',
+        message: 'Failed to get disposal or recovery codes'
+      })
+      .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}
+
+export const mapGetDisposalOrRecoveryCodesResponse = () =>
+  DISPOSAL_OR_RECOVERY_CODES.map((code) => ({
+    code
+  }))

--- a/src/handlers/reference-data/get-disposal-or-recovery-codes.test.js
+++ b/src/handlers/reference-data/get-disposal-or-recovery-codes.test.js
@@ -1,0 +1,85 @@
+import { describe, jest } from '@jest/globals'
+import {
+  handleGetDisposalOrRecoveryCodes,
+  mapGetDisposalOrRecoveryCodesResponse
+} from './get-disposal-or-recovery-codes.js'
+import * as handler from '../handle-backend-response.js'
+
+describe('GET Disposal or Recovery Codes', () => {
+  describe('Get Disposal or Recovery Codes Handler', () => {
+    const validPayload = mapGetDisposalOrRecoveryCodesResponse()
+    const request = {
+      auth: {
+        credentials: {
+          clientId: 'test-client-id'
+        }
+      },
+      payload: validPayload
+    }
+
+    it('should successfully get a list of disposal or recovery codes', async () => {
+      const h = {
+        response: jest.fn().mockReturnThis(),
+        code: jest.fn().mockReturnThis()
+      }
+
+      await handleGetDisposalOrRecoveryCodes(request, h)
+
+      expect(h.response).toHaveBeenCalledWith(validPayload)
+    })
+
+    it('should return 500 when request to get disposal or recovery codes fails', async () => {
+      jest.spyOn(handler, 'handleBackendResponse').mockImplementation(() => {
+        throw new Error('Internal Server Error')
+      })
+
+      const h = {
+        response: jest.fn().mockReturnThis(),
+        code: jest.fn().mockReturnThis()
+      }
+
+      await handleGetDisposalOrRecoveryCodes(request, h)
+
+      expect(h.response).toHaveBeenCalledWith({
+        statusCode: 500,
+        error: 'Internal Server Error',
+        message: 'Failed to get disposal or recovery codes'
+      })
+      expect(h.code).toHaveBeenCalledWith(500)
+    })
+  })
+
+  describe('mapGetDisposalOrRecoveryCodesResponse', () => {
+    it('should map disposal or recovery codes to the correct format', () => {
+      const codesResponse = mapGetDisposalOrRecoveryCodesResponse()
+
+      expect(codesResponse[0]).toStrictEqual({
+        code: 'R1'
+      })
+    })
+
+    it('should return the correct number of codes in total', () => {
+      const codesResponse = mapGetDisposalOrRecoveryCodesResponse()
+
+      expect(codesResponse.length).toBe(28)
+    })
+
+    it('should include recovery codes', () => {
+      const codesResponse = mapGetDisposalOrRecoveryCodesResponse()
+      const recoveryCodes = codesResponse.filter(({ code }) =>
+        code.startsWith('R')
+      )
+
+      expect(recoveryCodes.length).toBe(13)
+    })
+
+    it('should include disposal codes', () => {
+      const codesResponse = mapGetDisposalOrRecoveryCodesResponse()
+      const disposalCodes = codesResponse.filter(({ code }) =>
+        code.startsWith('D')
+      )
+
+      expect(disposalCodes.length).toBe(15)
+    })
+  })
+})

--- a/src/integration-tests/reference-data/get-disposal-or-recovery-codes.integration-test.js
+++ b/src/integration-tests/reference-data/get-disposal-or-recovery-codes.integration-test.js
@@ -1,0 +1,33 @@
+import { createServer } from '../server.js'
+import { MongoClient } from 'mongodb'
+import { mapGetDisposalOrRecoveryCodesResponse } from '../../handlers/reference-data/get-disposal-or-recovery-codes.js'
+
+describe('GET Disposal or Recovery Codes', () => {
+  let server
+  let mongoConnection
+
+  beforeAll(async () => {
+    server = await createServer()
+    mongoConnection = await MongoClient.connect('mongodb://localhost:27017', {})
+  })
+
+  afterAll(async () => {
+    server.stop()
+    mongoConnection.close()
+  })
+
+  it('should get disposal or recovery codes', async () => {
+    const expectedResponse = mapGetDisposalOrRecoveryCodesResponse()
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/reference-data/disposal-or-recovery-codes',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.result).toStrictEqual(expectedResponse)
+  })
+})

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -2,6 +2,7 @@ import { health } from '../routes/health.js'
 import { createReceiptMovement } from '../routes/create-receipt-movement.js'
 import { updateReceiptMovement } from '../routes/update-receipt-movement.js'
 import { getEwcCodes } from '../routes/reference-data/get-ewc-codes.js'
+import { getDisposalOrRecoveryCodes } from '../routes/reference-data/get-disposal-or-recovery-codes.js'
 
 const router = {
   plugin: {
@@ -12,7 +13,8 @@ const router = {
         health,
         createReceiptMovement,
         updateReceiptMovement,
-        getEwcCodes
+        getEwcCodes,
+        getDisposalOrRecoveryCodes
       ]
 
       // Register routes directly

--- a/src/routes/reference-data/get-disposal-or-recovery-codes.js
+++ b/src/routes/reference-data/get-disposal-or-recovery-codes.js
@@ -1,0 +1,25 @@
+import { HTTP_STATUS } from '../../common/constants/http-status-codes.js'
+import { handleGetDisposalOrRecoveryCodes } from '../../handlers/reference-data/get-disposal-or-recovery-codes.js'
+
+const getDisposalOrRecoveryCodes = {
+  method: 'GET',
+  path: '/reference-data/disposal-or-recovery-codes',
+  options: {
+    tags: ['reference-data'],
+    description:
+      'Endpoint to be used to get a list of disposal or recovery codes.',
+    plugins: {
+      'hapi-swagger': {
+        responses: {
+          [HTTP_STATUS.OK]: {
+            description:
+              'The list of disposal or recovery codes has been returned.'
+          }
+        }
+      }
+    }
+  },
+  handler: handleGetDisposalOrRecoveryCodes
+}
+
+export { getDisposalOrRecoveryCodes }


### PR DESCRIPTION
### Description
Ticket [DWT-719](https://eaflood.atlassian.net/browse/DWT-719)

New Handler: Implemented handleGetDisposalOrRecoveryCodes for processing requests to fetch disposal or recovery codes.
Route Addition: Registered a new endpoint /reference-data/disposal-or-recovery-codes in router.js and its corresponding route definition.
Unit Tests: Added unit tests to validate the handler function and its internal responses.
Integration Test: Introduced integration tests to ensure expected end-to-end behavior for the newly added endpoint.


[DWT-719]: https://eaflood.atlassian.net/browse/DWT-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ