### PR TITLE
DWT-718 Add Hazardous Property Codes Reference Data Endpoint

### DIFF
--- a/src/handlers/reference-data/get-hazardous-property-codes.js
+++ b/src/handlers/reference-data/get-hazardous-property-codes.js
@@ -1,0 +1,28 @@
+import { validHazCodes } from '../../common/constants/haz-codes.js'
+import { HTTP_STATUS } from '../../common/constants/http-status-codes.js'
+import { handleBackendResponse } from '../handle-backend-response.js'
+
+export const handleGetHazardousPropertyCodes = async (_request, h) => {
+  try {
+    const response = {
+      statusCode: HTTP_STATUS.OK
+    }
+    const responseData = mapGetHazardousPropertyCodesResponse()
+
+    return handleBackendResponse(response, h, () => responseData)
+  } catch (error) {
+    console.error('Error getting hazardous property codes:', error)
+    return h
+      .response({
+        statusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error: 'Internal Server Error',
+        message: 'Failed to get hazardous property codes'
+      })
+      .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}
+
+export const mapGetHazardousPropertyCodesResponse = () =>
+  validHazCodes.map((code) => ({
+    code
+  }))

--- a/src/handlers/reference-data/get-hazardous-property-codes.test.js
+++ b/src/handlers/reference-data/get-hazardous-property-codes.test.js
@@ -1,0 +1,67 @@
+import { describe, jest } from '@jest/globals'
+import * as handler from '../handle-backend-response.js'
+import {
+  handleGetHazardousPropertyCodes,
+  mapGetHazardousPropertyCodesResponse
+} from './get-hazardous-property-codes.js'
+
+describe('GET Hazardous Property Codes', () => {
+  describe('Get Hazardous Property Codes Handler', () => {
+    const validPayload = mapGetHazardousPropertyCodesResponse()
+    const request = {
+      auth: {
+        credentials: {
+          clientId: 'test-client-id'
+        }
+      },
+      payload: validPayload
+    }
+
+    it('should successfully get a list of hazardous property codes', async () => {
+      const h = {
+        response: jest.fn().mockReturnThis(),
+        code: jest.fn().mockReturnThis()
+      }
+
+      await handleGetHazardousPropertyCodes(request, h)
+
+      expect(h.response).toHaveBeenCalledWith(validPayload)
+    })
+
+    it('should return 500 when request to get hazardous property codes fails', async () => {
+      jest.spyOn(handler, 'handleBackendResponse').mockImplementation(() => {
+        throw new Error('Internal Server Error')
+      })
+
+      const h = {
+        response: jest.fn().mockReturnThis(),
+        code: jest.fn().mockReturnThis()
+      }
+
+      await handleGetHazardousPropertyCodes(request, h)
+
+      expect(h.response).toHaveBeenCalledWith({
+        statusCode: 500,
+        error: 'Internal Server Error',
+        message: 'Failed to get hazardous property codes'
+      })
+      expect(h.code).toHaveBeenCalledWith(500)
+    })
+  })
+
+  describe('mapGetHazardousPropertyCodesResponse', () => {
+    it('should map hazardous property codes to the correct format', () => {
+      const hazPropertyCodesResponse = mapGetHazardousPropertyCodesResponse()
+
+      expect(hazPropertyCodesResponse[0]).toStrictEqual({
+        code: 'HP_1'
+      })
+    })
+
+    it('should return the correct number of codes', () => {
+      const hazPropertyCodesResponse = mapGetHazardousPropertyCodesResponse()
+
+      expect(hazPropertyCodesResponse.length).toBe(16)
+    })
+  })
+})

--- a/src/integration-tests/reference-data/get-hazardous-property-codes.integration-test.js
+++ b/src/integration-tests/reference-data/get-hazardous-property-codes.integration-test.js
@@ -1,0 +1,33 @@
+import { createServer } from '../server.js'
+import { MongoClient } from 'mongodb'
+import { mapGetHazardousPropertyCodesResponse } from '../../handlers/reference-data/get-hazardous-property-codes.js'
+
+describe('GET Hazardous Property Codes', () => {
+  let server
+  let mongoConnection
+
+  beforeAll(async () => {
+    server = await createServer()
+    mongoConnection = await MongoClient.connect('mongodb://localhost:27017', {})
+  })
+
+  afterAll(async () => {
+    server.stop()
+    mongoConnection.close()
+  })
+
+  it('should get hazardous property codes', async () => {
+    const expectedResponse = mapGetHazardousPropertyCodesResponse()
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/reference-data/hazardous-property-codes',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.result).toStrictEqual(expectedResponse)
+  })
+})

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -3,6 +3,7 @@ import { createReceiptMovement } from '../routes/create-receipt-movement.js'
 import { updateReceiptMovement } from '../routes/update-receipt-movement.js'
 import { getEwcCodes } from '../routes/reference-data/get-ewc-codes.js'
 import { getDisposalOrRecoveryCodes } from '../routes/reference-data/get-disposal-or-recovery-codes.js'
+import { getHazardousPropertyCodes } from '../routes/reference-data/get-hazardous-property-codes.js'
 
 const router = {
   plugin: {
@@ -14,7 +15,8 @@ const router = {
         createReceiptMovement,
         updateReceiptMovement,
         getEwcCodes,
-        getDisposalOrRecoveryCodes
+        getDisposalOrRecoveryCodes,
+        getHazardousPropertyCodes
       ]
 
       // Register routes directly

--- a/src/routes/reference-data/get-hazardous-property-codes.js
+++ b/src/routes/reference-data/get-hazardous-property-codes.js
@@ -1,0 +1,25 @@
+import { HTTP_STATUS } from '../../common/constants/http-status-codes.js'
+import { handleGetHazardousPropertyCodes } from '../../handlers/reference-data/get-hazardous-property-codes.js'
+
+const getHazardousPropertyCodes = {
+  method: 'GET',
+  path: '/reference-data/hazardous-property-codes',
+  options: {
+    tags: ['reference-data'],
+    description:
+      'Endpoint to be used to get a list of hazardous property codes.',
+    plugins: {
+      'hapi-swagger': {
+        responses: {
+          [HTTP_STATUS.OK]: {
+            description:
+              'The list of hazardous property codes has been returned.'
+          }
+        }
+      }
+    }
+  },
+  handler: handleGetHazardousPropertyCodes
+}
+
+export { getHazardousPropertyCodes }


### PR DESCRIPTION
Ticket [DWT-718](https://eaflood.atlassian.net/browse/DWT-718)

This change adds a new `/reference-data/hazardous-property-codes` endpoint to return Hazardous Property Codes, following the pattern of other new Reference Data endpoints

Changes:
- Add `/reference-data/hazardous-property-codes` router and handler
- Add handler unit tests
- Add endpoint integration tests