### PR TITLE
DWTA-148 Change the Consignment Note Number format validation

### DIFF
--- a/src/common/constants/validation-error-messages.js
+++ b/src/common/constants/validation-error-messages.js
@@ -60,7 +60,7 @@ export const HAZARDOUS_ERRORS = {
 // Hazardous waste consignment messages
 export const CONSIGNMENT_ERRORS = {
   CODE_FORMAT:
-    '{{#label}} must be in one of the valid formats: EA/NRW (e.g. CJTILE/A0001), SEPA (SA|SB|SC followed by 7 digits), or NIEA (DA|DB|DC followed by 7 digits)',
+    '{{#label}} must be in one of the valid formats: EA/NRW (2 or more alphanumeric characters followed by / and 5-6 alphanumeric characters, e.g. CJTILE/A0001), SEPA (SA|SB|SC followed by 7 digits), or NIEA (DA|DB|DC followed by 7 digits)',
   CODE_REQUIRED: '{{#label}} is required when hazardous EWC codes are present',
   REASON_REQUIRED:
     '"reasonForNoConsignmentCode" is required when wasteItems[*].ewcCodes contains a hazardous code and hazardousWasteConsignmentCode is not provided',

--- a/src/schemas/hazardous-waste-consignment.js
+++ b/src/schemas/hazardous-waste-consignment.js
@@ -3,10 +3,10 @@ import { isValidHazardousEwcCode } from '../common/constants/ewc-codes.js'
 import { CONSIGNMENT_ERRORS } from '../common/constants/validation-error-messages.js'
 
 // Consignment note code formats, e.g.
-// CJTILE/A0001
+// CJTILE/A0001 or CJ123E/A0001
 // SA1234567
 // DA1234567
-const EA_NRW_PATTERN = /^[A-Za-z]{2,}\/[A-Za-z0-9]{5}[A-Za-z]?$/
+const EA_NRW_PATTERN = /^[A-Za-z0-9]{2,}\/[A-Za-z0-9]{5}[A-Za-z]?$/
 const SEPA_PATTERN = /^S[ABC]\d{7}$/
 const NIEA_PATTERN = /^D[ABC]\d{7}$/
 

--- a/src/schemas/hazardous-waste-consignment.test.js
+++ b/src/schemas/hazardous-waste-consignment.test.js
@@ -193,6 +193,15 @@ describe('Hazardous Waste Consignment Note Code rules', () => {
     // The error handler will extract 'InvalidValue' category from this type
   })
 
+  it('Accept EA/NRW consignment code with alphanumeric prefix (letters and numbers before slash)', () => {
+    const payload = buildBasePayload()
+    payload.wasteItems[0].ewcCodes = ['030104'] // hazardous
+    payload.hazardousWasteConsignmentCode = 'CJ123E/A0001'
+
+    const { error } = receiveMovementRequestSchema.validate(payload)
+    expect(error).toBeUndefined()
+  })
+
   it('should return InvalidFormat.consignmentCode error type for invalid consignment code format', () => {
     const payload = buildBasePayload()
     payload.wasteItems[0].ewcCodes = ['030104'] // hazardous


### PR DESCRIPTION
### Description
Ticket [DWTA-148](https://eaflood.atlassian.net/browse/DWTA-148)

- Updated validation regex to permit alphanumeric prefixes for EA/NRW consignment codes.
- Added test cases to ensure the new validation rules are functional.

[DWTA-148]: https://eaflood.atlassian.net/browse/DWTA-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ