### PR TITLE
DWTA-223 Incorrect unique Client ID value in Grafana

### DIFF
--- a/src/common/constants/metric-names.js
+++ b/src/common/constants/metric-names.js
@@ -1,0 +1,10 @@
+export const METRIC_NAMES = {
+  RECEIPTS_RECEIVED: 'receipts.received',
+  VALIDATION_WARNINGS_COUNT: 'validation.warnings.count',
+  VALIDATION_REQUESTS_WITH_WARNINGS: 'validation.requests.with_warnings',
+  VALIDATION_REQUESTS_WITHOUT_WARNINGS: 'validation.requests.without_warnings',
+  VALIDATION_WARNING_REASON: 'validation.warning.reason',
+  VALIDATION_REQUESTS_WITHOUT_ERRORS: 'validation.requests.without_errors',
+  DEVELOPERS_ACTIVE: 'developers.active',
+  DEVELOPERS_ATTEMPTED: 'developers.attempted'
+}

--- a/src/common/constants/metric-names.js
+++ b/src/common/constants/metric-names.js
@@ -5,6 +5,11 @@ export const METRIC_NAMES = {
   VALIDATION_REQUESTS_WITHOUT_WARNINGS: 'validation.requests.without_warnings',
   VALIDATION_WARNING_REASON: 'validation.warning.reason',
   VALIDATION_REQUESTS_WITHOUT_ERRORS: 'validation.requests.without_errors',
+  VALIDATION_REQUESTS_WITH_ERRORS: 'validation.requests.with_errors',
+  VALIDATION_ERRORS_COUNT: 'validation.errors.count',
+  VALIDATION_ERROR_REASON: 'validation.error.reason',
+  VALIDATION_ERROR_CATEGORY: 'validation.error.category',
+  ERRORS_BY_STATUS_CODE: 'errors.by_status_code',
   DEVELOPERS_ACTIVE: 'developers.active',
   DEVELOPERS_ATTEMPTED: 'developers.attempted'
 }

--- a/src/common/helpers/metrics.js
+++ b/src/common/helpers/metrics.js
@@ -38,18 +38,24 @@ const metricsCounter = async (metricName, value = 1, dimensions = {}) => {
 /**
  * Logs receipt received metrics with endpoint type dimension and total
  * @param {string} endpointType - The endpoint type ('post' or 'put')
+ * @param {string} [clientId] - Optional clientId for per-vendor breakdown
  */
-const logReceiptMetrics = async (endpointType) => {
+const logReceiptMetrics = async (endpointType, clientId) => {
   await metricsCounter('receipts.received', 1, { endpointType })
   await metricsCounter('receipts.received', 1)
+  if (clientId) {
+    await metricsCounter('receipts.received', 1, { endpointType, clientId })
+    await metricsCounter('receipts.received', 1, { clientId })
+  }
 }
 
 /**
  * Logs validation warning metrics with endpoint type dimension and total
  * @param {Array} warnings - The validation warnings array
  * @param {string} endpointType - The endpoint type ('post' or 'put')
+ * @param {string} [clientId] - Optional clientId for per-vendor breakdown
  */
-const logWarningMetrics = async (warnings, endpointType) => {
+const logWarningMetrics = async (warnings, endpointType, clientId) => {
   if (warnings.length > 0) {
     await metricsCounter('validation.warnings.count', warnings.length, {
       endpointType
@@ -59,6 +65,23 @@ const logWarningMetrics = async (warnings, endpointType) => {
       endpointType
     })
     await metricsCounter('validation.requests.with_warnings', 1)
+
+    if (clientId) {
+      await metricsCounter('validation.warnings.count', warnings.length, {
+        endpointType,
+        clientId
+      })
+      await metricsCounter('validation.warnings.count', warnings.length, {
+        clientId
+      })
+      await metricsCounter('validation.requests.with_warnings', 1, {
+        endpointType,
+        clientId
+      })
+      await metricsCounter('validation.requests.with_warnings', 1, {
+        clientId
+      })
+    }
 
     // Per-warning breakdown metrics
     for (const warning of warnings) {
@@ -70,17 +93,39 @@ const logWarningMetrics = async (warnings, endpointType) => {
       await metricsCounter('validation.warning.reason', 1, {
         warningReason
       })
+      if (clientId) {
+        await metricsCounter('validation.warning.reason', 1, {
+          endpointType,
+          warningReason,
+          clientId
+        })
+        await metricsCounter('validation.warning.reason', 1, {
+          warningReason,
+          clientId
+        })
+      }
     }
   } else {
     await metricsCounter('validation.requests.without_warnings', 1, {
       endpointType
     })
     await metricsCounter('validation.requests.without_warnings', 1)
+    if (clientId) {
+      await metricsCounter('validation.requests.without_warnings', 1, {
+        endpointType,
+        clientId
+      })
+      await metricsCounter('validation.requests.without_warnings', 1, {
+        clientId
+      })
+    }
   }
 }
 
 /**
- * Logs developer activity metrics with clientId dimension for unique counting
+ * Logs developer activity metrics with clientId dimension for unique counting.
+ * Emitted on successful receipt movements only — represents developers
+ * actively transacting.
  * @param {string} clientId - The developer's client ID
  */
 const logDeveloperMetrics = async (clientId) => {
@@ -88,9 +133,22 @@ const logDeveloperMetrics = async (clientId) => {
   await metricsCounter('developers.active', 1)
 }
 
+/**
+ * Logs attempted developer activity metrics with clientId dimension.
+ * Emitted on every authenticated receipt movement attempt, regardless of
+ * outcome — represents developers who have hit the API at all (the canonical
+ * source for the "Active Client IDs" panel).
+ * @param {string} clientId - The developer's client ID
+ */
+const logAttemptedDeveloperMetrics = async (clientId) => {
+  await metricsCounter('developers.attempted', 1, { clientId })
+  await metricsCounter('developers.attempted', 1)
+}
+
 export {
   metricsCounter,
   logReceiptMetrics,
   logWarningMetrics,
-  logDeveloperMetrics
+  logDeveloperMetrics,
+  logAttemptedDeveloperMetrics
 }

--- a/src/common/helpers/metrics.js
+++ b/src/common/helpers/metrics.js
@@ -36,128 +36,82 @@ const metricsCounter = async (metricName, value = 1, dimensions = {}) => {
   }
 }
 
+// Build dimensions object including clientId only when present.
+// Dashboards aggregate across clientId via SEARCH() wildcards.
+const withClientId = (dims, clientId) =>
+  clientId ? { ...dims, clientId } : dims
+
 /**
- * Logs receipt received metrics with endpoint type dimension and total
+ * Logs receipt received metric.
  * @param {string} endpointType - The endpoint type ('post' or 'put')
  * @param {string} [clientId] - Optional clientId for per-vendor breakdown
  */
 const logReceiptMetrics = async (endpointType, clientId) => {
-  await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1, { endpointType })
-  await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1)
-  if (clientId) {
-    await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1, {
-      endpointType,
-      clientId
-    })
-    await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1, { clientId })
-  }
+  await metricsCounter(
+    METRIC_NAMES.RECEIPTS_RECEIVED,
+    1,
+    withClientId({ endpointType }, clientId)
+  )
 }
 
 /**
- * Logs validation warning metrics with endpoint type dimension and total
+ * Logs validation warning metrics.
  * @param {Array} warnings - The validation warnings array
  * @param {string} endpointType - The endpoint type ('post' or 'put')
  * @param {string} [clientId] - Optional clientId for per-vendor breakdown
  */
 const logWarningMetrics = async (warnings, endpointType, clientId) => {
+  const baseDims = withClientId({ endpointType }, clientId)
+
   if (warnings.length > 0) {
     await metricsCounter(
       METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
       warnings.length,
-      { endpointType }
+      baseDims
     )
     await metricsCounter(
-      METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
-      warnings.length
+      METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS,
+      1,
+      baseDims
     )
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1, {
-      endpointType
-    })
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1)
 
-    if (clientId) {
-      await metricsCounter(
-        METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
-        warnings.length,
-        { endpointType, clientId }
-      )
-      await metricsCounter(
-        METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
-        warnings.length,
-        { clientId }
-      )
-      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1, {
-        endpointType,
-        clientId
-      })
-      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1, {
-        clientId
-      })
-    }
-
-    // Per-warning breakdown metrics
     for (const warning of warnings) {
       const warningReason = normalizeArrayIndices(warning.message)
       await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
-        endpointType,
+        ...baseDims,
         warningReason
       })
-      await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
-        warningReason
-      })
-      if (clientId) {
-        await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
-          endpointType,
-          warningReason,
-          clientId
-        })
-        await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
-          warningReason,
-          clientId
-        })
-      }
     }
   } else {
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS, 1, {
-      endpointType
-    })
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS, 1)
-    if (clientId) {
-      await metricsCounter(
-        METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS,
-        1,
-        { endpointType, clientId }
-      )
-      await metricsCounter(
-        METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS,
-        1,
-        { clientId }
-      )
-    }
+    await metricsCounter(
+      METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS,
+      1,
+      baseDims
+    )
   }
 }
 
 /**
- * Logs developer activity metrics with clientId dimension for unique counting.
- * Emitted on successful receipt movements only — represents developers
- * actively transacting.
+ * Logs developer activity metric. Emitted on successful receipt movements
+ * only — represents developers actively transacting.
  * @param {string} clientId - The developer's client ID
  */
 const logDeveloperMetrics = async (clientId) => {
   await metricsCounter(METRIC_NAMES.DEVELOPERS_ACTIVE, 1, { clientId })
-  await metricsCounter(METRIC_NAMES.DEVELOPERS_ACTIVE, 1)
 }
 
 /**
- * Logs attempted developer activity metrics with clientId dimension.
- * Emitted on every authenticated receipt movement attempt, regardless of
- * outcome — represents developers who have hit the API at all (the canonical
- * source for the "Active Client IDs" panel).
+ * Logs attempted developer activity metric. Emitted on every authenticated
+ * receipt movement attempt regardless of outcome — represents developers
+ * who have hit the API at all (canonical source for the "Active Client IDs"
+ * panel).
  * @param {string} clientId - The developer's client ID
  */
 const logAttemptedDeveloperMetrics = async (clientId) => {
+  if (!clientId) {
+    return
+  }
   await metricsCounter(METRIC_NAMES.DEVELOPERS_ATTEMPTED, 1, { clientId })
-  await metricsCounter(METRIC_NAMES.DEVELOPERS_ATTEMPTED, 1)
 }
 
 export {

--- a/src/common/helpers/metrics.js
+++ b/src/common/helpers/metrics.js
@@ -6,6 +6,7 @@ import {
 import { config } from '../../config.js'
 import { createLogger } from './logging/logger.js'
 import { normalizeArrayIndices } from './utils.js'
+import { METRIC_NAMES } from '../constants/metric-names.js'
 
 /**
  * Logs a counter metric with optional dimensions
@@ -41,11 +42,14 @@ const metricsCounter = async (metricName, value = 1, dimensions = {}) => {
  * @param {string} [clientId] - Optional clientId for per-vendor breakdown
  */
 const logReceiptMetrics = async (endpointType, clientId) => {
-  await metricsCounter('receipts.received', 1, { endpointType })
-  await metricsCounter('receipts.received', 1)
+  await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1, { endpointType })
+  await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1)
   if (clientId) {
-    await metricsCounter('receipts.received', 1, { endpointType, clientId })
-    await metricsCounter('receipts.received', 1, { clientId })
+    await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1, {
+      endpointType,
+      clientId
+    })
+    await metricsCounter(METRIC_NAMES.RECEIPTS_RECEIVED, 1, { clientId })
   }
 }
 
@@ -57,28 +61,36 @@ const logReceiptMetrics = async (endpointType, clientId) => {
  */
 const logWarningMetrics = async (warnings, endpointType, clientId) => {
   if (warnings.length > 0) {
-    await metricsCounter('validation.warnings.count', warnings.length, {
+    await metricsCounter(
+      METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
+      warnings.length,
+      { endpointType }
+    )
+    await metricsCounter(
+      METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
+      warnings.length
+    )
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1, {
       endpointType
     })
-    await metricsCounter('validation.warnings.count', warnings.length)
-    await metricsCounter('validation.requests.with_warnings', 1, {
-      endpointType
-    })
-    await metricsCounter('validation.requests.with_warnings', 1)
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1)
 
     if (clientId) {
-      await metricsCounter('validation.warnings.count', warnings.length, {
+      await metricsCounter(
+        METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
+        warnings.length,
+        { endpointType, clientId }
+      )
+      await metricsCounter(
+        METRIC_NAMES.VALIDATION_WARNINGS_COUNT,
+        warnings.length,
+        { clientId }
+      )
+      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1, {
         endpointType,
         clientId
       })
-      await metricsCounter('validation.warnings.count', warnings.length, {
-        clientId
-      })
-      await metricsCounter('validation.requests.with_warnings', 1, {
-        endpointType,
-        clientId
-      })
-      await metricsCounter('validation.requests.with_warnings', 1, {
+      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS, 1, {
         clientId
       })
     }
@@ -86,38 +98,41 @@ const logWarningMetrics = async (warnings, endpointType, clientId) => {
     // Per-warning breakdown metrics
     for (const warning of warnings) {
       const warningReason = normalizeArrayIndices(warning.message)
-      await metricsCounter('validation.warning.reason', 1, {
+      await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
         endpointType,
         warningReason
       })
-      await metricsCounter('validation.warning.reason', 1, {
+      await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
         warningReason
       })
       if (clientId) {
-        await metricsCounter('validation.warning.reason', 1, {
+        await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
           endpointType,
           warningReason,
           clientId
         })
-        await metricsCounter('validation.warning.reason', 1, {
+        await metricsCounter(METRIC_NAMES.VALIDATION_WARNING_REASON, 1, {
           warningReason,
           clientId
         })
       }
     }
   } else {
-    await metricsCounter('validation.requests.without_warnings', 1, {
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS, 1, {
       endpointType
     })
-    await metricsCounter('validation.requests.without_warnings', 1)
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS, 1)
     if (clientId) {
-      await metricsCounter('validation.requests.without_warnings', 1, {
-        endpointType,
-        clientId
-      })
-      await metricsCounter('validation.requests.without_warnings', 1, {
-        clientId
-      })
+      await metricsCounter(
+        METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS,
+        1,
+        { endpointType, clientId }
+      )
+      await metricsCounter(
+        METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS,
+        1,
+        { clientId }
+      )
     }
   }
 }
@@ -129,8 +144,8 @@ const logWarningMetrics = async (warnings, endpointType, clientId) => {
  * @param {string} clientId - The developer's client ID
  */
 const logDeveloperMetrics = async (clientId) => {
-  await metricsCounter('developers.active', 1, { clientId })
-  await metricsCounter('developers.active', 1)
+  await metricsCounter(METRIC_NAMES.DEVELOPERS_ACTIVE, 1, { clientId })
+  await metricsCounter(METRIC_NAMES.DEVELOPERS_ACTIVE, 1)
 }
 
 /**
@@ -141,8 +156,8 @@ const logDeveloperMetrics = async (clientId) => {
  * @param {string} clientId - The developer's client ID
  */
 const logAttemptedDeveloperMetrics = async (clientId) => {
-  await metricsCounter('developers.attempted', 1, { clientId })
-  await metricsCounter('developers.attempted', 1)
+  await metricsCounter(METRIC_NAMES.DEVELOPERS_ATTEMPTED, 1, { clientId })
+  await metricsCounter(METRIC_NAMES.DEVELOPERS_ATTEMPTED, 1)
 }
 
 export {

--- a/src/common/helpers/metrics.test.js
+++ b/src/common/helpers/metrics.test.js
@@ -191,4 +191,64 @@ describe('#logWarningMetrics', () => {
       expect.objectContaining({ warningReason: expect.any(String) })
     )
   })
+
+  test('Should emit clientId-scoped variants when clientId provided', async () => {
+    const warnings = [
+      {
+        key: 'wasteItems[0].weight',
+        errorType: 'Warning',
+        message: '"wasteItems[0].weight.metric" is missing'
+      }
+    ]
+
+    await logWarningMetrics(warnings, 'post', 'test-client-id')
+
+    // Original dim-sets still emitted
+    expect(mockPutDimensions).toHaveBeenCalledWith({ endpointType: 'post' })
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      endpointType: 'post',
+      warningReason: '"wasteItems[*].weight.metric" is missing'
+    })
+
+    // ClientId-scoped variants
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      endpointType: 'post',
+      clientId: 'test-client-id'
+    })
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      clientId: 'test-client-id'
+    })
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      endpointType: 'post',
+      warningReason: '"wasteItems[*].weight.metric" is missing',
+      clientId: 'test-client-id'
+    })
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      warningReason: '"wasteItems[*].weight.metric" is missing',
+      clientId: 'test-client-id'
+    })
+  })
+
+  test('Should emit clientId-scoped without_warnings when no warnings and clientId provided', async () => {
+    await logWarningMetrics([], 'put', 'test-client-id')
+
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      endpointType: 'put',
+      clientId: 'test-client-id'
+    })
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      clientId: 'test-client-id'
+    })
+  })
+
+  test('Should not emit clientId variants when clientId omitted', async () => {
+    await logWarningMetrics(
+      [{ key: 'x', errorType: 'Warning', message: 'something is missing' }],
+      'post'
+    )
+
+    expect(mockPutDimensions).not.toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: expect.anything() })
+    )
+  })
 })

--- a/src/common/helpers/metrics.test.js
+++ b/src/common/helpers/metrics.test.js
@@ -1,7 +1,12 @@
 import { StorageResolution, Unit } from 'aws-embedded-metrics'
 
 import { config } from '../../config.js'
-import { metricsCounter, logWarningMetrics } from './metrics.js'
+import {
+  metricsCounter,
+  logWarningMetrics,
+  logReceiptMetrics,
+  logAttemptedDeveloperMetrics
+} from './metrics.js'
 
 const mockPutMetric = jest.fn()
 const mockPutDimensions = jest.fn()
@@ -147,13 +152,7 @@ describe('#logWarningMetrics', () => {
       warningReason: '"wasteItems[*].weight.metric" is missing'
     })
     expect(mockPutDimensions).toHaveBeenCalledWith({
-      warningReason: '"wasteItems[*].weight.metric" is missing'
-    })
-    expect(mockPutDimensions).toHaveBeenCalledWith({
       endpointType: 'post',
-      warningReason: '"wasteItems[*].weight.isEstimate" is missing'
-    })
-    expect(mockPutDimensions).toHaveBeenCalledWith({
       warningReason: '"wasteItems[*].weight.isEstimate" is missing'
     })
   })
@@ -192,7 +191,7 @@ describe('#logWarningMetrics', () => {
     )
   })
 
-  test('Should emit clientId-scoped variants when clientId provided', async () => {
+  test('Should append clientId to all dimensions when provided', async () => {
     const warnings = [
       {
         key: 'wasteItems[0].weight',
@@ -203,19 +202,9 @@ describe('#logWarningMetrics', () => {
 
     await logWarningMetrics(warnings, 'post', 'test-client-id')
 
-    // Original dim-sets still emitted
-    expect(mockPutDimensions).toHaveBeenCalledWith({ endpointType: 'post' })
+    // Single emission per metric with maximal dim set including clientId
     expect(mockPutDimensions).toHaveBeenCalledWith({
       endpointType: 'post',
-      warningReason: '"wasteItems[*].weight.metric" is missing'
-    })
-
-    // ClientId-scoped variants
-    expect(mockPutDimensions).toHaveBeenCalledWith({
-      endpointType: 'post',
-      clientId: 'test-client-id'
-    })
-    expect(mockPutDimensions).toHaveBeenCalledWith({
       clientId: 'test-client-id'
     })
     expect(mockPutDimensions).toHaveBeenCalledWith({
@@ -223,22 +212,19 @@ describe('#logWarningMetrics', () => {
       warningReason: '"wasteItems[*].weight.metric" is missing',
       clientId: 'test-client-id'
     })
-    expect(mockPutDimensions).toHaveBeenCalledWith({
-      warningReason: '"wasteItems[*].weight.metric" is missing',
-      clientId: 'test-client-id'
-    })
+    // Old un-clientId-scoped variants no longer emitted
+    expect(mockPutDimensions).not.toHaveBeenCalledWith({ endpointType: 'post' })
   })
 
-  test('Should emit clientId-scoped without_warnings when no warnings and clientId provided', async () => {
+  test('Should emit without_warnings with clientId when no warnings and clientId provided', async () => {
     await logWarningMetrics([], 'put', 'test-client-id')
 
     expect(mockPutDimensions).toHaveBeenCalledWith({
       endpointType: 'put',
       clientId: 'test-client-id'
     })
-    expect(mockPutDimensions).toHaveBeenCalledWith({
-      clientId: 'test-client-id'
-    })
+    // Only one emission, not two
+    expect(mockPutDimensions).toHaveBeenCalledTimes(1)
   })
 
   test('Should not emit clientId variants when clientId omitted', async () => {
@@ -250,5 +236,71 @@ describe('#logWarningMetrics', () => {
     expect(mockPutDimensions).not.toHaveBeenCalledWith(
       expect.objectContaining({ clientId: expect.anything() })
     )
+  })
+})
+
+describe('#logReceiptMetrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    config.set('isMetricsEnabled', true)
+  })
+
+  test('Should emit a single endpointType-scoped metric when clientId omitted', async () => {
+    await logReceiptMetrics('post')
+
+    expect(mockPutDimensions).toHaveBeenCalledWith({ endpointType: 'post' })
+    expect(mockPutDimensions).toHaveBeenCalledTimes(1)
+    expect(mockPutMetric).toHaveBeenCalledWith(
+      'receipts.received',
+      1,
+      Unit.Count,
+      StorageResolution.Standard
+    )
+    expect(mockPutMetric).toHaveBeenCalledTimes(1)
+  })
+
+  test('Should append clientId to dimensions when provided', async () => {
+    await logReceiptMetrics('post', 'test-client-id')
+
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      endpointType: 'post',
+      clientId: 'test-client-id'
+    })
+    expect(mockPutDimensions).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('#logAttemptedDeveloperMetrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    config.set('isMetricsEnabled', true)
+  })
+
+  test('Should emit developers.attempted with clientId dim', async () => {
+    await logAttemptedDeveloperMetrics('test-client-id')
+
+    expect(mockPutDimensions).toHaveBeenCalledWith({
+      clientId: 'test-client-id'
+    })
+    expect(mockPutMetric).toHaveBeenCalledWith(
+      'developers.attempted',
+      1,
+      Unit.Count,
+      StorageResolution.Standard
+    )
+    expect(mockPutMetric).toHaveBeenCalledTimes(1)
+  })
+
+  test('Should not emit when clientId is absent', async () => {
+    await logAttemptedDeveloperMetrics()
+
+    expect(mockPutMetric).not.toHaveBeenCalled()
+    expect(mockPutDimensions).not.toHaveBeenCalled()
+  })
+
+  test('Should not emit when clientId is empty string', async () => {
+    await logAttemptedDeveloperMetrics('')
+
+    expect(mockPutMetric).not.toHaveBeenCalled()
   })
 })

--- a/src/common/helpers/receipt-movement-endpoint.js
+++ b/src/common/helpers/receipt-movement-endpoint.js
@@ -1,0 +1,12 @@
+/**
+ * Check if request is for receipt movement endpoints
+ * @param {Object} request - The Hapi request object
+ * @returns {boolean}
+ */
+export const isReceiptMovementEndpoint = (request) => {
+  const path = request.route?.path
+  return (
+    path === '/movements/receive' ||
+    path === '/movements/{wasteTrackingId}/receive'
+  )
+}

--- a/src/handlers/create-receipt-movement.js
+++ b/src/handlers/create-receipt-movement.js
@@ -10,6 +10,7 @@ import {
   logWarningMetrics,
   logDeveloperMetrics
 } from '../common/helpers/metrics.js'
+import { METRIC_NAMES } from '../common/constants/metric-names.js'
 import { addSubmittingOrganisationToRequest } from '../common/helpers/submitting-organisation.js'
 
 const logger = createLogger()
@@ -55,16 +56,16 @@ export const handleCreateReceiptMovement = async (request, h) => {
     const clientId = request.auth?.credentials?.clientId
 
     // Request passed validation (no validation errors) - log regardless of backend response
-    await metricsCounter('validation.requests.without_errors', 1, {
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
       endpointType: 'post'
     })
-    await metricsCounter('validation.requests.without_errors', 1)
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1)
     if (clientId) {
-      await metricsCounter('validation.requests.without_errors', 1, {
+      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
         endpointType: 'post',
         clientId
       })
-      await metricsCounter('validation.requests.without_errors', 1, {
+      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
         clientId
       })
     }

--- a/src/handlers/create-receipt-movement.js
+++ b/src/handlers/create-receipt-movement.js
@@ -57,7 +57,9 @@ export const handleCreateReceiptMovement = async (request, h) => {
 
     // Request passed validation (no validation errors) - log regardless of backend response
     const withoutErrorsDims = { endpointType: 'post' }
-    if (clientId) withoutErrorsDims.clientId = clientId
+    if (clientId) {
+      withoutErrorsDims.clientId = clientId
+    }
     await metricsCounter(
       METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS,
       1,

--- a/src/handlers/create-receipt-movement.js
+++ b/src/handlers/create-receipt-movement.js
@@ -52,17 +52,27 @@ export const handleCreateReceiptMovement = async (request, h) => {
       }
     }
 
+    const clientId = request.auth?.credentials?.clientId
+
     // Request passed validation (no validation errors) - log regardless of backend response
     await metricsCounter('validation.requests.without_errors', 1, {
       endpointType: 'post'
     })
     await metricsCounter('validation.requests.without_errors', 1)
+    if (clientId) {
+      await metricsCounter('validation.requests.without_errors', 1, {
+        endpointType: 'post',
+        clientId
+      })
+      await metricsCounter('validation.requests.without_errors', 1, {
+        clientId
+      })
+    }
 
     // Only log metrics for successful responses
     if (isSuccess) {
-      await logReceiptMetrics('post')
-      await logWarningMetrics(warnings, 'post')
-      const clientId = request.auth?.credentials?.clientId
+      await logReceiptMetrics('post', clientId)
+      await logWarningMetrics(warnings, 'post', clientId)
       if (clientId) {
         await logDeveloperMetrics(clientId)
       }

--- a/src/handlers/create-receipt-movement.js
+++ b/src/handlers/create-receipt-movement.js
@@ -56,19 +56,13 @@ export const handleCreateReceiptMovement = async (request, h) => {
     const clientId = request.auth?.credentials?.clientId
 
     // Request passed validation (no validation errors) - log regardless of backend response
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
-      endpointType: 'post'
-    })
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1)
-    if (clientId) {
-      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
-        endpointType: 'post',
-        clientId
-      })
-      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
-        clientId
-      })
-    }
+    const withoutErrorsDims = { endpointType: 'post' }
+    if (clientId) withoutErrorsDims.clientId = clientId
+    await metricsCounter(
+      METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS,
+      1,
+      withoutErrorsDims
+    )
 
     // Only log metrics for successful responses
     if (isSuccess) {

--- a/src/handlers/create-receipt-movement.test.js
+++ b/src/handlers/create-receipt-movement.test.js
@@ -150,9 +150,27 @@ describe('Create Receipt Movement Handler', () => {
       'validation.requests.without_errors',
       1
     )
+    // ClientId-scoped variants
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { endpointType: 'post', clientId: 'test-client-id' }
+    )
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { clientId: 'test-client-id' }
+    )
     // Receipt received metrics
-    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('post')
-    expect(metrics.logWarningMetrics).toHaveBeenCalledWith([], 'post')
+    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
+      'post',
+      'test-client-id'
+    )
+    expect(metrics.logWarningMetrics).toHaveBeenCalledWith(
+      [],
+      'post',
+      'test-client-id'
+    )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
   })
@@ -196,7 +214,10 @@ describe('Create Receipt Movement Handler', () => {
       1
     )
     // Receipt received metrics
-    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('post')
+    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
+      'post',
+      'test-client-id'
+    )
     expect(metrics.logWarningMetrics).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
@@ -204,7 +225,8 @@ describe('Create Receipt Movement Handler', () => {
           key: 'wasteItems.0.disposalOrRecoveryCodes'
         })
       ]),
-      'post'
+      'post',
+      'test-client-id'
     )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
@@ -263,11 +285,17 @@ describe('Create Receipt Movement Handler', () => {
 
     await handleCreateReceiptMovement(requestWithoutAuth, h)
 
-    // Receipt and warning metrics should still be logged
-    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('post')
+    // Receipt and warning metrics should still be logged (clientId undefined)
+    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('post', undefined)
     expect(metrics.logWarningMetrics).toHaveBeenCalled()
     // Developer metrics should NOT be logged when clientId is missing
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
+    // ClientId-scoped without_errors variants should NOT be emitted
+    expect(metrics.metricsCounter).not.toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      expect.objectContaining({ clientId: expect.anything() })
+    )
   })
 
   it('should log without_errors but not warning or receipt metrics when backend returns non-success status', async () => {
@@ -294,11 +322,22 @@ describe('Create Receipt Movement Handler', () => {
       'validation.requests.without_errors',
       1
     )
+    // ClientId-scoped variants also emitted (clientId present on request)
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { endpointType: 'post', clientId: 'test-client-id' }
+    )
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { clientId: 'test-client-id' }
+    )
     // Receipt, warning, and developer metrics should NOT be logged
     expect(metrics.logReceiptMetrics).not.toHaveBeenCalled()
     expect(metrics.logWarningMetrics).not.toHaveBeenCalled()
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
-    expect(metrics.metricsCounter).toHaveBeenCalledTimes(2)
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(4)
     expect(h.code).toHaveBeenCalledWith(400)
   })
 })

--- a/src/handlers/create-receipt-movement.test.js
+++ b/src/handlers/create-receipt-movement.test.js
@@ -139,28 +139,13 @@ describe('Create Receipt Movement Handler', () => {
       }
     )
 
-    // Verify metrics are logged on success (no warnings case)
-    // Requests without validation errors (passed validation)
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { endpointType: 'post' }
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1
-    )
-    // ClientId-scoped variants
+    // Single emission with clientId-scoped dim set
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
       { endpointType: 'post', clientId: 'test-client-id' }
     )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { clientId: 'test-client-id' }
-    )
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     // Receipt received metrics
     expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
       'post',
@@ -202,17 +187,13 @@ describe('Create Receipt Movement Handler', () => {
 
     await handleCreateReceiptMovement(requestWithWarnings, h)
 
-    // Verify metrics are logged on success (with warnings case)
-    // Requests without validation errors (passed validation)
+    // Single emission with clientId-scoped dim set
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
-      { endpointType: 'post' }
+      { endpointType: 'post', clientId: 'test-client-id' }
     )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1
-    )
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     // Receipt received metrics
     expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
       'post',
@@ -290,7 +271,12 @@ describe('Create Receipt Movement Handler', () => {
     expect(metrics.logWarningMetrics).toHaveBeenCalled()
     // Developer metrics should NOT be logged when clientId is missing
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
-    // ClientId-scoped without_errors variants should NOT be emitted
+    // without_errors emission omits clientId when absent
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { endpointType: 'post' }
+    )
     expect(metrics.metricsCounter).not.toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
@@ -312,32 +298,17 @@ describe('Create Receipt Movement Handler', () => {
 
     await handleCreateReceiptMovement(request, h)
 
-    // without_errors should still be logged (request passed validation)
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { endpointType: 'post' }
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1
-    )
-    // ClientId-scoped variants also emitted (clientId present on request)
+    // without_errors logged with clientId-scoped dim set
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
       { endpointType: 'post', clientId: 'test-client-id' }
     )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { clientId: 'test-client-id' }
-    )
     // Receipt, warning, and developer metrics should NOT be logged
     expect(metrics.logReceiptMetrics).not.toHaveBeenCalled()
     expect(metrics.logWarningMetrics).not.toHaveBeenCalled()
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
-    expect(metrics.metricsCounter).toHaveBeenCalledTimes(4)
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     expect(h.code).toHaveBeenCalledWith(400)
   })
 })

--- a/src/handlers/update-receipt-movement.js
+++ b/src/handlers/update-receipt-movement.js
@@ -8,6 +8,7 @@ import {
   logWarningMetrics,
   logDeveloperMetrics
 } from '../common/helpers/metrics.js'
+import { METRIC_NAMES } from '../common/constants/metric-names.js'
 import { isSuccessStatusCode } from '../common/helpers/utils.js'
 import { addSubmittingOrganisationToRequest } from '../common/helpers/submitting-organisation.js'
 
@@ -47,16 +48,16 @@ export const handleUpdateReceiptMovement = async (request, h) => {
     const clientId = request.auth?.credentials?.clientId
 
     // Request passed validation (no validation errors) - log regardless of backend response
-    await metricsCounter('validation.requests.without_errors', 1, {
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
       endpointType: 'put'
     })
-    await metricsCounter('validation.requests.without_errors', 1)
+    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1)
     if (clientId) {
-      await metricsCounter('validation.requests.without_errors', 1, {
+      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
         endpointType: 'put',
         clientId
       })
-      await metricsCounter('validation.requests.without_errors', 1, {
+      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
         clientId
       })
     }

--- a/src/handlers/update-receipt-movement.js
+++ b/src/handlers/update-receipt-movement.js
@@ -48,19 +48,13 @@ export const handleUpdateReceiptMovement = async (request, h) => {
     const clientId = request.auth?.credentials?.clientId
 
     // Request passed validation (no validation errors) - log regardless of backend response
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
-      endpointType: 'put'
-    })
-    await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1)
-    if (clientId) {
-      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
-        endpointType: 'put',
-        clientId
-      })
-      await metricsCounter(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS, 1, {
-        clientId
-      })
-    }
+    const withoutErrorsDims = { endpointType: 'put' }
+    if (clientId) withoutErrorsDims.clientId = clientId
+    await metricsCounter(
+      METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS,
+      1,
+      withoutErrorsDims
+    )
 
     // Only log metrics for successful responses
     if (isSuccessStatusCode(response.statusCode)) {

--- a/src/handlers/update-receipt-movement.js
+++ b/src/handlers/update-receipt-movement.js
@@ -49,7 +49,9 @@ export const handleUpdateReceiptMovement = async (request, h) => {
 
     // Request passed validation (no validation errors) - log regardless of backend response
     const withoutErrorsDims = { endpointType: 'put' }
-    if (clientId) withoutErrorsDims.clientId = clientId
+    if (clientId) {
+      withoutErrorsDims.clientId = clientId
+    }
     await metricsCounter(
       METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS,
       1,

--- a/src/handlers/update-receipt-movement.js
+++ b/src/handlers/update-receipt-movement.js
@@ -44,17 +44,27 @@ export const handleUpdateReceiptMovement = async (request, h) => {
       }
     }
 
+    const clientId = request.auth?.credentials?.clientId
+
     // Request passed validation (no validation errors) - log regardless of backend response
     await metricsCounter('validation.requests.without_errors', 1, {
       endpointType: 'put'
     })
     await metricsCounter('validation.requests.without_errors', 1)
+    if (clientId) {
+      await metricsCounter('validation.requests.without_errors', 1, {
+        endpointType: 'put',
+        clientId
+      })
+      await metricsCounter('validation.requests.without_errors', 1, {
+        clientId
+      })
+    }
 
     // Only log metrics for successful responses
     if (isSuccessStatusCode(response.statusCode)) {
-      await logReceiptMetrics('put')
-      await logWarningMetrics(warnings, 'put')
-      const clientId = request.auth?.credentials?.clientId
+      await logReceiptMetrics('put', clientId)
+      await logWarningMetrics(warnings, 'put', clientId)
       if (clientId) {
         await logDeveloperMetrics(clientId)
       }

--- a/src/plugins/error-handler.js
+++ b/src/plugins/error-handler.js
@@ -1,5 +1,6 @@
 import { metricsCounter } from '../common/helpers/metrics.js'
 import { normalizeArrayIndices } from '../common/helpers/utils.js'
+import { isReceiptMovementEndpoint } from '../common/helpers/receipt-movement-endpoint.js'
 
 const JOI_TYPE_TO_CATEGORY = {
   // NotProvided
@@ -62,17 +63,6 @@ function getErrorCategory(joiErrorType) {
   }
 
   return 'UnexpectedError'
-}
-
-/**
- * Check if request is for receipt movement endpoints
- */
-const isReceiptMovementEndpoint = (request) => {
-  const path = request.route.path
-  return (
-    path === '/movements/receive' ||
-    path === '/movements/{wasteTrackingId}/receive'
-  )
 }
 
 export const errorHandler = {
@@ -147,6 +137,7 @@ export const errorHandler = {
           // Log validation error metrics for receipt movement endpoints
           if (isReceiptMovementEndpoint(request)) {
             const endpointType = request.method.toLowerCase()
+            const clientId = request.auth?.credentials?.clientId
 
             // Error count metrics
             await metricsCounter(
@@ -167,6 +158,26 @@ export const errorHandler = {
             })
             await metricsCounter('validation.requests.with_errors', 1)
 
+            if (clientId) {
+              await metricsCounter(
+                'validation.errors.count',
+                formattedErrors.length,
+                { endpointType, clientId }
+              )
+              await metricsCounter(
+                'validation.errors.count',
+                formattedErrors.length,
+                { clientId }
+              )
+              await metricsCounter('validation.requests.with_errors', 1, {
+                endpointType,
+                clientId
+              })
+              await metricsCounter('validation.requests.with_errors', 1, {
+                clientId
+              })
+            }
+
             // Per-error breakdown metrics
             for (const error of formattedErrors) {
               const errorReason = normalizeArrayIndices(error.message)
@@ -186,6 +197,27 @@ export const errorHandler = {
               await metricsCounter('validation.error.category', 1, {
                 errorCategory: error.errorType
               })
+
+              if (clientId) {
+                await metricsCounter('validation.error.reason', 1, {
+                  endpointType,
+                  errorReason,
+                  clientId
+                })
+                await metricsCounter('validation.error.reason', 1, {
+                  errorReason,
+                  clientId
+                })
+                await metricsCounter('validation.error.category', 1, {
+                  endpointType,
+                  errorCategory: error.errorType,
+                  clientId
+                })
+                await metricsCounter('validation.error.category', 1, {
+                  errorCategory: error.errorType,
+                  clientId
+                })
+              }
             }
 
             // HTTP status code metric for validation errors
@@ -196,6 +228,17 @@ export const errorHandler = {
             await metricsCounter('errors.by_status_code', 1, {
               statusCode: '400'
             })
+            if (clientId) {
+              await metricsCounter('errors.by_status_code', 1, {
+                endpointType,
+                statusCode: '400',
+                clientId
+              })
+              await metricsCounter('errors.by_status_code', 1, {
+                statusCode: '400',
+                clientId
+              })
+            }
           }
 
           // Return the custom formatted error
@@ -210,6 +253,7 @@ export const errorHandler = {
         ) {
           const endpointType = request.method.toLowerCase()
           const statusCode = String(response.output.statusCode)
+          const clientId = request.auth?.credentials?.clientId
 
           await metricsCounter('errors.by_status_code', 1, {
             endpointType,
@@ -218,6 +262,17 @@ export const errorHandler = {
           await metricsCounter('errors.by_status_code', 1, {
             statusCode
           })
+          if (clientId) {
+            await metricsCounter('errors.by_status_code', 1, {
+              endpointType,
+              statusCode,
+              clientId
+            })
+            await metricsCounter('errors.by_status_code', 1, {
+              statusCode,
+              clientId
+            })
+          }
         }
 
         // If not a validation error, continue with the default response

--- a/src/plugins/error-handler.js
+++ b/src/plugins/error-handler.js
@@ -1,6 +1,11 @@
 import { metricsCounter } from '../common/helpers/metrics.js'
 import { normalizeArrayIndices } from '../common/helpers/utils.js'
 import { isReceiptMovementEndpoint } from '../common/helpers/receipt-movement-endpoint.js'
+import { METRIC_NAMES } from '../common/constants/metric-names.js'
+
+// Build dimensions object including clientId only when present.
+const withClientId = (dims, clientId) =>
+  clientId ? { ...dims, clientId } : dims
 
 const JOI_TYPE_TO_CATEGORY = {
   // NotProvided
@@ -138,107 +143,35 @@ export const errorHandler = {
           if (isReceiptMovementEndpoint(request)) {
             const endpointType = request.method.toLowerCase()
             const clientId = request.auth?.credentials?.clientId
+            const baseDims = withClientId({ endpointType }, clientId)
 
-            // Error count metrics
             await metricsCounter(
-              'validation.errors.count',
+              METRIC_NAMES.VALIDATION_ERRORS_COUNT,
               formattedErrors.length,
-              {
-                endpointType
-              }
+              baseDims
             )
             await metricsCounter(
-              'validation.errors.count',
-              formattedErrors.length
+              METRIC_NAMES.VALIDATION_REQUESTS_WITH_ERRORS,
+              1,
+              baseDims
             )
 
-            // Request with errors metric
-            await metricsCounter('validation.requests.with_errors', 1, {
-              endpointType
-            })
-            await metricsCounter('validation.requests.with_errors', 1)
-
-            if (clientId) {
-              await metricsCounter(
-                'validation.errors.count',
-                formattedErrors.length,
-                { endpointType, clientId }
-              )
-              await metricsCounter(
-                'validation.errors.count',
-                formattedErrors.length,
-                { clientId }
-              )
-              await metricsCounter('validation.requests.with_errors', 1, {
-                endpointType,
-                clientId
-              })
-              await metricsCounter('validation.requests.with_errors', 1, {
-                clientId
-              })
-            }
-
-            // Per-error breakdown metrics
             for (const error of formattedErrors) {
               const errorReason = normalizeArrayIndices(error.message)
-              await metricsCounter('validation.error.reason', 1, {
-                endpointType,
+              await metricsCounter(METRIC_NAMES.VALIDATION_ERROR_REASON, 1, {
+                ...baseDims,
                 errorReason
               })
-              await metricsCounter('validation.error.reason', 1, {
-                errorReason
-              })
-
-              // Error category metrics (NotProvided, InvalidType, etc.)
-              await metricsCounter('validation.error.category', 1, {
-                endpointType,
+              await metricsCounter(METRIC_NAMES.VALIDATION_ERROR_CATEGORY, 1, {
+                ...baseDims,
                 errorCategory: error.errorType
               })
-              await metricsCounter('validation.error.category', 1, {
-                errorCategory: error.errorType
-              })
-
-              if (clientId) {
-                await metricsCounter('validation.error.reason', 1, {
-                  endpointType,
-                  errorReason,
-                  clientId
-                })
-                await metricsCounter('validation.error.reason', 1, {
-                  errorReason,
-                  clientId
-                })
-                await metricsCounter('validation.error.category', 1, {
-                  endpointType,
-                  errorCategory: error.errorType,
-                  clientId
-                })
-                await metricsCounter('validation.error.category', 1, {
-                  errorCategory: error.errorType,
-                  clientId
-                })
-              }
             }
 
-            // HTTP status code metric for validation errors
-            await metricsCounter('errors.by_status_code', 1, {
-              endpointType,
+            await metricsCounter(METRIC_NAMES.ERRORS_BY_STATUS_CODE, 1, {
+              ...baseDims,
               statusCode: '400'
             })
-            await metricsCounter('errors.by_status_code', 1, {
-              statusCode: '400'
-            })
-            if (clientId) {
-              await metricsCounter('errors.by_status_code', 1, {
-                endpointType,
-                statusCode: '400',
-                clientId
-              })
-              await metricsCounter('errors.by_status_code', 1, {
-                statusCode: '400',
-                clientId
-              })
-            }
           }
 
           // Return the custom formatted error
@@ -255,24 +188,10 @@ export const errorHandler = {
           const statusCode = String(response.output.statusCode)
           const clientId = request.auth?.credentials?.clientId
 
-          await metricsCounter('errors.by_status_code', 1, {
-            endpointType,
+          await metricsCounter(METRIC_NAMES.ERRORS_BY_STATUS_CODE, 1, {
+            ...withClientId({ endpointType }, clientId),
             statusCode
           })
-          await metricsCounter('errors.by_status_code', 1, {
-            statusCode
-          })
-          if (clientId) {
-            await metricsCounter('errors.by_status_code', 1, {
-              endpointType,
-              statusCode,
-              clientId
-            })
-            await metricsCounter('errors.by_status_code', 1, {
-              statusCode,
-              clientId
-            })
-          }
         }
 
         // If not a validation error, continue with the default response

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -161,24 +161,16 @@ describe('Error Handler', () => {
     const responseBody = JSON.parse(response.payload)
     const errorCount = responseBody.validation.errors.length
 
-    // Verify metrics were called with correct arguments
+    // Single emission per metric with endpointType dim (no clientId in test env)
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.errors.count',
       errorCount,
       { endpointType: 'post' }
     )
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.errors.count',
-      errorCount
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.with_errors',
       1,
       { endpointType: 'post' }
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.with_errors',
-      1
     )
   })
 
@@ -195,24 +187,16 @@ describe('Error Handler', () => {
     const responseBody = JSON.parse(response.payload)
     const errorCount = responseBody.validation.errors.length
 
-    // Verify metrics were called with correct arguments
+    // Single emission per metric with endpointType dim (no clientId in test env)
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.errors.count',
       errorCount,
       { endpointType: 'put' }
     )
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.errors.count',
-      errorCount
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.with_errors',
       1,
       { endpointType: 'put' }
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.with_errors',
-      1
     )
   })
 
@@ -239,13 +223,13 @@ describe('Error Handler', () => {
     const responseBody = JSON.parse(response.payload)
     const errorCount = responseBody.validation.errors.length
 
-    // Should have:
-    // - 2 calls for errors.count (with dimension + without)
-    // - 2 calls for requests.with_errors (with dimension + without)
-    // - 2 calls per validation error for error.reason (with dimension + without)
-    // - 2 calls per validation error for error.category (with dimension + without)
-    // - 2 calls for errors.by_status_code (with dimension + without)
-    const expectedCalls = 6 + errorCount * 4
+    // Single emission per metric (no clientId in this test — auth disabled):
+    // - 1 call for errors.count
+    // - 1 call for requests.with_errors
+    // - 1 call per error for error.reason
+    // - 1 call per error for error.category
+    // - 1 call for errors.by_status_code
+    const expectedCalls = 3 + errorCount * 2
     expect(metrics.metricsCounter).toHaveBeenCalledTimes(expectedCalls)
 
     // Helper function matching production normalization logic
@@ -255,17 +239,10 @@ describe('Error Handler', () => {
     for (const error of responseBody.validation.errors) {
       const expectedReason = normalizeArrayIndices(error.message)
 
-      // Should be called with endpointType + errorReason
       expect(metrics.metricsCounter).toHaveBeenCalledWith(
         'validation.error.reason',
         1,
         { endpointType: 'post', errorReason: expectedReason }
-      )
-      // Should also be called with just errorReason (for totals)
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'validation.error.reason',
-        1,
-        { errorReason: expectedReason }
       )
     }
   })
@@ -620,17 +597,12 @@ describe('Error Handler', () => {
       expect(response.statusCode).toBe(400)
       const responseBody = JSON.parse(response.payload)
 
-      // Verify error category metrics were called for each error
+      // Single emission per error with endpointType + errorCategory
       for (const error of responseBody.validation.errors) {
         expect(metrics.metricsCounter).toHaveBeenCalledWith(
           'validation.error.category',
           1,
           { endpointType: 'post', errorCategory: error.errorType }
-        )
-        expect(metrics.metricsCounter).toHaveBeenCalledWith(
-          'validation.error.category',
-          1,
-          { errorCategory: error.errorType }
         )
       }
     })
@@ -683,17 +655,12 @@ describe('Error Handler', () => {
       expect(response.statusCode).toBe(400)
       const responseBody = JSON.parse(response.payload)
 
-      // Verify error category metrics were called with PUT endpoint type
+      // Single emission per error with endpointType + errorCategory
       for (const error of responseBody.validation.errors) {
         expect(metrics.metricsCounter).toHaveBeenCalledWith(
           'validation.error.category',
           1,
           { endpointType: 'put', errorCategory: error.errorType }
-        )
-        expect(metrics.metricsCounter).toHaveBeenCalledWith(
-          'validation.error.category',
-          1,
-          { errorCategory: error.errorType }
         )
       }
     })
@@ -711,16 +678,11 @@ describe('Error Handler', () => {
 
       expect(response.statusCode).toBe(400)
 
-      // Verify status code metrics were called
+      // Single emission with endpointType + statusCode
       expect(metrics.metricsCounter).toHaveBeenCalledWith(
         'errors.by_status_code',
         1,
         { endpointType: 'post', statusCode: '400' }
-      )
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'errors.by_status_code',
-        1,
-        { statusCode: '400' }
       )
     })
 
@@ -735,16 +697,11 @@ describe('Error Handler', () => {
 
       expect(response.statusCode).toBe(400)
 
-      // Verify status code metrics were called with PUT endpoint type
+      // Single emission with endpointType + statusCode
       expect(metrics.metricsCounter).toHaveBeenCalledWith(
         'errors.by_status_code',
         1,
         { endpointType: 'put', statusCode: '400' }
-      )
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'errors.by_status_code',
-        1,
-        { statusCode: '400' }
       )
     })
 
@@ -762,16 +719,11 @@ describe('Error Handler', () => {
 
       expect(response.statusCode).toBe(404)
 
-      // Verify status code metrics were called with 404
+      // Single emission with endpointType + statusCode
       expect(metrics.metricsCounter).toHaveBeenCalledWith(
         'errors.by_status_code',
         1,
         { endpointType: 'put', statusCode: '404' }
-      )
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'errors.by_status_code',
-        1,
-        { statusCode: '404' }
       )
     })
   })
@@ -801,7 +753,7 @@ describe('Error Handler', () => {
       injectClientId = null
     })
 
-    test('should emit clientId-scoped variants for POST validation errors', async () => {
+    test('should include clientId in all metric dim sets for POST validation errors', async () => {
       const response = await server.inject({
         method: 'POST',
         url: '/movements/receive',
@@ -811,29 +763,19 @@ describe('Error Handler', () => {
       expect(response.statusCode).toBe(400)
       const responseBody = JSON.parse(response.payload)
 
-      // Aggregate counts (errors.count, requests.with_errors) — clientId variants
+      // Aggregate counts — single emission with endpointType + clientId
       expect(metrics.metricsCounter).toHaveBeenCalledWith(
         'validation.errors.count',
         responseBody.validation.errors.length,
         { endpointType: 'post', clientId: 'test-client-id' }
       )
       expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'validation.errors.count',
-        responseBody.validation.errors.length,
-        { clientId: 'test-client-id' }
-      )
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
         'validation.requests.with_errors',
         1,
         { endpointType: 'post', clientId: 'test-client-id' }
-      )
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'validation.requests.with_errors',
-        1,
-        { clientId: 'test-client-id' }
       )
 
-      // Per-error breakdown — clientId variants
+      // Per-error breakdown with endpointType + clientId
       const normalizeArrayIndices = (str) => str.replace(/\[\d+]/g, '[*]')
       for (const error of responseBody.validation.errors) {
         const errorReason = normalizeArrayIndices(error.message)
@@ -841,11 +783,6 @@ describe('Error Handler', () => {
           'validation.error.reason',
           1,
           { endpointType: 'post', errorReason, clientId: 'test-client-id' }
-        )
-        expect(metrics.metricsCounter).toHaveBeenCalledWith(
-          'validation.error.reason',
-          1,
-          { errorReason, clientId: 'test-client-id' }
         )
         expect(metrics.metricsCounter).toHaveBeenCalledWith(
           'validation.error.category',
@@ -856,14 +793,9 @@ describe('Error Handler', () => {
             clientId: 'test-client-id'
           }
         )
-        expect(metrics.metricsCounter).toHaveBeenCalledWith(
-          'validation.error.category',
-          1,
-          { errorCategory: error.errorType, clientId: 'test-client-id' }
-        )
       }
 
-      // Status code — clientId variants
+      // Status code with endpointType + clientId
       expect(metrics.metricsCounter).toHaveBeenCalledWith(
         'errors.by_status_code',
         1,
@@ -873,14 +805,16 @@ describe('Error Handler', () => {
           clientId: 'test-client-id'
         }
       )
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'errors.by_status_code',
+
+      // Old un-clientId-scoped emissions no longer happen
+      expect(metrics.metricsCounter).not.toHaveBeenCalledWith(
+        'validation.requests.with_errors',
         1,
-        { statusCode: '400', clientId: 'test-client-id' }
+        { endpointType: 'post' }
       )
     })
 
-    test('should emit clientId-scoped variants for PUT validation errors', async () => {
+    test('should include clientId for PUT validation errors', async () => {
       const response = await server.inject({
         method: 'PUT',
         url: '/movements/test-tracking-id/receive',
@@ -901,7 +835,7 @@ describe('Error Handler', () => {
       )
     })
 
-    test('should emit clientId-scoped variant for non-400 errors', async () => {
+    test('should include clientId for non-400 errors', async () => {
       const notFoundError = new Error('Movement not found')
       notFoundError.name = 'NotFoundError'
       httpClients.wasteMovement.put.mockRejectedValueOnce(notFoundError)
@@ -919,14 +853,9 @@ describe('Error Handler', () => {
         1,
         { endpointType: 'put', statusCode: '404', clientId: 'test-client-id' }
       )
-      expect(metrics.metricsCounter).toHaveBeenCalledWith(
-        'errors.by_status_code',
-        1,
-        { statusCode: '404', clientId: 'test-client-id' }
-      )
     })
 
-    test('should not emit clientId variants when clientId absent', async () => {
+    test('should omit clientId from dim sets when clientId absent', async () => {
       injectClientId = null
 
       const response = await server.inject({

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -775,4 +775,172 @@ describe('Error Handler', () => {
       )
     })
   })
+
+  describe('ClientId-scoped metrics', () => {
+    let injectClientId
+
+    beforeAll(() => {
+      // JWT is disabled in test/local env (no strategy registered).
+      // Use an onPostAuth hook (fires after auth, before validation) to
+      // inject mock credentials so error-handler's
+      // request.auth?.credentials?.clientId resolves even when validation
+      // short-circuits the handler.
+      server.ext('onPostAuth', (request, h) => {
+        if (injectClientId && request.auth) {
+          request.auth.credentials = { clientId: injectClientId }
+        }
+        return h.continue
+      })
+    })
+
+    beforeEach(() => {
+      injectClientId = 'test-client-id'
+    })
+
+    afterEach(() => {
+      injectClientId = null
+    })
+
+    test('should emit clientId-scoped variants for POST validation errors', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/movements/receive',
+        payload: { yourUniqueReference: 'test' }
+      })
+
+      expect(response.statusCode).toBe(400)
+      const responseBody = JSON.parse(response.payload)
+
+      // Aggregate counts (errors.count, requests.with_errors) — clientId variants
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'validation.errors.count',
+        responseBody.validation.errors.length,
+        { endpointType: 'post', clientId: 'test-client-id' }
+      )
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'validation.errors.count',
+        responseBody.validation.errors.length,
+        { clientId: 'test-client-id' }
+      )
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'validation.requests.with_errors',
+        1,
+        { endpointType: 'post', clientId: 'test-client-id' }
+      )
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'validation.requests.with_errors',
+        1,
+        { clientId: 'test-client-id' }
+      )
+
+      // Per-error breakdown — clientId variants
+      const normalizeArrayIndices = (str) => str.replace(/\[\d+]/g, '[*]')
+      for (const error of responseBody.validation.errors) {
+        const errorReason = normalizeArrayIndices(error.message)
+        expect(metrics.metricsCounter).toHaveBeenCalledWith(
+          'validation.error.reason',
+          1,
+          { endpointType: 'post', errorReason, clientId: 'test-client-id' }
+        )
+        expect(metrics.metricsCounter).toHaveBeenCalledWith(
+          'validation.error.reason',
+          1,
+          { errorReason, clientId: 'test-client-id' }
+        )
+        expect(metrics.metricsCounter).toHaveBeenCalledWith(
+          'validation.error.category',
+          1,
+          {
+            endpointType: 'post',
+            errorCategory: error.errorType,
+            clientId: 'test-client-id'
+          }
+        )
+        expect(metrics.metricsCounter).toHaveBeenCalledWith(
+          'validation.error.category',
+          1,
+          { errorCategory: error.errorType, clientId: 'test-client-id' }
+        )
+      }
+
+      // Status code — clientId variants
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'errors.by_status_code',
+        1,
+        {
+          endpointType: 'post',
+          statusCode: '400',
+          clientId: 'test-client-id'
+        }
+      )
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'errors.by_status_code',
+        1,
+        { statusCode: '400', clientId: 'test-client-id' }
+      )
+    })
+
+    test('should emit clientId-scoped variants for PUT validation errors', async () => {
+      const response = await server.inject({
+        method: 'PUT',
+        url: '/movements/test-tracking-id/receive',
+        payload: { yourUniqueReference: 'test' }
+      })
+
+      expect(response.statusCode).toBe(400)
+
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'validation.requests.with_errors',
+        1,
+        { endpointType: 'put', clientId: 'test-client-id' }
+      )
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'errors.by_status_code',
+        1,
+        { endpointType: 'put', statusCode: '400', clientId: 'test-client-id' }
+      )
+    })
+
+    test('should emit clientId-scoped variant for non-400 errors', async () => {
+      const notFoundError = new Error('Movement not found')
+      notFoundError.name = 'NotFoundError'
+      httpClients.wasteMovement.put.mockRejectedValueOnce(notFoundError)
+
+      const response = await server.inject({
+        method: 'PUT',
+        url: '/movements/test-tracking-id/receive',
+        payload: createMovementRequest()
+      })
+
+      expect(response.statusCode).toBe(404)
+
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'errors.by_status_code',
+        1,
+        { endpointType: 'put', statusCode: '404', clientId: 'test-client-id' }
+      )
+      expect(metrics.metricsCounter).toHaveBeenCalledWith(
+        'errors.by_status_code',
+        1,
+        { statusCode: '404', clientId: 'test-client-id' }
+      )
+    })
+
+    test('should not emit clientId variants when clientId absent', async () => {
+      injectClientId = null
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/movements/receive',
+        payload: { yourUniqueReference: 'test' }
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(metrics.metricsCounter).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Number),
+        expect.objectContaining({ clientId: expect.anything() })
+      )
+    })
+  })
 })

--- a/src/plugins/request-metrics.js
+++ b/src/plugins/request-metrics.js
@@ -1,0 +1,25 @@
+import { logAttemptedDeveloperMetrics } from '../common/helpers/metrics.js'
+import { isReceiptMovementEndpoint } from '../common/helpers/receipt-movement-endpoint.js'
+
+export const requestMetrics = {
+  plugin: {
+    name: 'requestMetrics',
+    register: async (server) => {
+      // Emit developers.attempted once per authenticated receipt-movement
+      // request, regardless of validation outcome or backend response.
+      // This is the canonical source for the "Active Client IDs" panel —
+      // developers.active only fires on success and undercounts vendors
+      // stuck in onboarding.
+      server.ext('onPostAuth', async (request, h) => {
+        if (!isReceiptMovementEndpoint(request)) {
+          return h.continue
+        }
+        const clientId = request.auth?.credentials?.clientId
+        if (clientId) {
+          await logAttemptedDeveloperMetrics(clientId)
+        }
+        return h.continue
+      })
+    }
+  }
+}

--- a/src/plugins/request-metrics.test.js
+++ b/src/plugins/request-metrics.test.js
@@ -1,0 +1,101 @@
+import Hapi from '@hapi/hapi'
+import { requestMetrics } from './request-metrics.js'
+import * as metrics from '../common/helpers/metrics.js'
+
+jest.mock('../common/helpers/metrics.js', () => ({
+  logAttemptedDeveloperMetrics: jest.fn()
+}))
+
+const buildServer = async ({ withAuth }) => {
+  const server = Hapi.server()
+
+  if (withAuth) {
+    server.auth.scheme('mock', () => ({
+      authenticate: (request, h) =>
+        h.authenticated({ credentials: { clientId: 'test-client-id' } })
+    }))
+    server.auth.strategy('mock', 'mock')
+    server.auth.default('mock')
+  }
+
+  server.route([
+    {
+      method: 'POST',
+      path: '/movements/receive',
+      handler: () => ({ ok: true })
+    },
+    {
+      method: 'PUT',
+      path: '/movements/{wasteTrackingId}/receive',
+      handler: () => ({ ok: true })
+    },
+    {
+      method: 'GET',
+      path: '/health',
+      options: { auth: false },
+      handler: () => ({ ok: true })
+    }
+  ])
+
+  await server.register(requestMetrics)
+  return server
+}
+
+describe('requestMetrics plugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('emits developers.attempted for authenticated POST receipt movement', async () => {
+    const server = await buildServer({ withAuth: true })
+
+    await server.inject({
+      method: 'POST',
+      url: '/movements/receive',
+      payload: {}
+    })
+
+    expect(metrics.logAttemptedDeveloperMetrics).toHaveBeenCalledWith(
+      'test-client-id'
+    )
+    expect(metrics.logAttemptedDeveloperMetrics).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits developers.attempted for authenticated PUT receipt movement', async () => {
+    const server = await buildServer({ withAuth: true })
+
+    await server.inject({
+      method: 'PUT',
+      url: '/movements/abc-123/receive',
+      payload: {}
+    })
+
+    expect(metrics.logAttemptedDeveloperMetrics).toHaveBeenCalledWith(
+      'test-client-id'
+    )
+    expect(metrics.logAttemptedDeveloperMetrics).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not emit for non-receipt-movement routes', async () => {
+    const server = await buildServer({ withAuth: true })
+
+    await server.inject({
+      method: 'GET',
+      url: '/health'
+    })
+
+    expect(metrics.logAttemptedDeveloperMetrics).not.toHaveBeenCalled()
+  })
+
+  it('does not emit when clientId is absent (unauthenticated)', async () => {
+    const server = await buildServer({ withAuth: false })
+
+    await server.inject({
+      method: 'POST',
+      url: '/movements/receive',
+      payload: {}
+    })
+
+    expect(metrics.logAttemptedDeveloperMetrics).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -120,8 +120,22 @@ describe('handleUpdateReceiptMovement', () => {
       'validation.requests.without_errors',
       1
     )
+    // ClientId-scoped variants
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { endpointType: 'put', clientId: 'test-client-id' }
+    )
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { clientId: 'test-client-id' }
+    )
     // Receipt received metrics
-    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('put')
+    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
+      'put',
+      'test-client-id'
+    )
     expect(metrics.logWarningMetrics).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
@@ -129,7 +143,8 @@ describe('handleUpdateReceiptMovement', () => {
           key: 'wasteItems.0.disposalOrRecoveryCodes'
         })
       ]),
-      'put'
+      'put',
+      'test-client-id'
     )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
@@ -192,9 +207,27 @@ describe('handleUpdateReceiptMovement', () => {
       'validation.requests.without_errors',
       1
     )
+    // ClientId-scoped variants
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { endpointType: 'put', clientId: 'test-client-id' }
+    )
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { clientId: 'test-client-id' }
+    )
     // Receipt received metrics
-    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('put')
-    expect(metrics.logWarningMetrics).toHaveBeenCalledWith([], 'put')
+    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
+      'put',
+      'test-client-id'
+    )
+    expect(metrics.logWarningMetrics).toHaveBeenCalledWith(
+      [],
+      'put',
+      'test-client-id'
+    )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
   })
@@ -232,11 +265,17 @@ describe('handleUpdateReceiptMovement', () => {
 
     await handleUpdateReceiptMovement(requestWithoutAuth, mockH)
 
-    // Receipt and warning metrics should still be logged
-    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('put')
+    // Receipt and warning metrics should still be logged (clientId undefined)
+    expect(metrics.logReceiptMetrics).toHaveBeenCalledWith('put', undefined)
     expect(metrics.logWarningMetrics).toHaveBeenCalled()
     // Developer metrics should NOT be logged when clientId is missing
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
+    // ClientId-scoped without_errors variants should NOT be emitted
+    expect(metrics.metricsCounter).not.toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      expect.objectContaining({ clientId: expect.anything() })
+    )
   })
 
   it('should log without_errors but not warning or receipt metrics when backend returns non-success status', async () => {
@@ -257,11 +296,22 @@ describe('handleUpdateReceiptMovement', () => {
       'validation.requests.without_errors',
       1
     )
+    // ClientId-scoped variants also emitted (clientId present on request)
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { endpointType: 'put', clientId: 'test-client-id' }
+    )
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { clientId: 'test-client-id' }
+    )
     // Receipt, warning, and developer metrics should NOT be logged
     expect(metrics.logReceiptMetrics).not.toHaveBeenCalled()
     expect(metrics.logWarningMetrics).not.toHaveBeenCalled()
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
-    expect(metrics.metricsCounter).toHaveBeenCalledTimes(2)
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(4)
     expect(mockH.code).toHaveBeenCalledWith(400)
   })
 })

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -109,28 +109,13 @@ describe('handleUpdateReceiptMovement', () => {
 
     expect(mockH.code).toHaveBeenCalledWith(200)
 
-    // Verify metrics are logged on success (with warnings case)
-    // Requests without validation errors (passed validation)
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { endpointType: 'put' }
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1
-    )
-    // ClientId-scoped variants
+    // Single emission with clientId-scoped dim set
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
       { endpointType: 'put', clientId: 'test-client-id' }
     )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { clientId: 'test-client-id' }
-    )
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     // Receipt received metrics
     expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
       'put',
@@ -196,28 +181,13 @@ describe('handleUpdateReceiptMovement', () => {
 
     expect(mockH.code).toHaveBeenCalledWith(200)
 
-    // Verify metrics are logged on success (no warnings case)
-    // Requests without validation errors (passed validation)
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { endpointType: 'put' }
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1
-    )
-    // ClientId-scoped variants
+    // Single emission with clientId-scoped dim set
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
       { endpointType: 'put', clientId: 'test-client-id' }
     )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { clientId: 'test-client-id' }
-    )
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     // Receipt received metrics
     expect(metrics.logReceiptMetrics).toHaveBeenCalledWith(
       'put',
@@ -270,7 +240,12 @@ describe('handleUpdateReceiptMovement', () => {
     expect(metrics.logWarningMetrics).toHaveBeenCalled()
     // Developer metrics should NOT be logged when clientId is missing
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
-    // ClientId-scoped without_errors variants should NOT be emitted
+    // without_errors emission omits clientId when absent
+    expect(metrics.metricsCounter).toHaveBeenCalledWith(
+      'validation.requests.without_errors',
+      1,
+      { endpointType: 'put' }
+    )
     expect(metrics.metricsCounter).not.toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
@@ -286,32 +261,17 @@ describe('handleUpdateReceiptMovement', () => {
 
     await handleUpdateReceiptMovement(mockRequest, mockH)
 
-    // without_errors should still be logged (request passed validation)
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { endpointType: 'put' }
-    )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1
-    )
-    // ClientId-scoped variants also emitted (clientId present on request)
+    // without_errors logged with clientId-scoped dim set
     expect(metrics.metricsCounter).toHaveBeenCalledWith(
       'validation.requests.without_errors',
       1,
       { endpointType: 'put', clientId: 'test-client-id' }
     )
-    expect(metrics.metricsCounter).toHaveBeenCalledWith(
-      'validation.requests.without_errors',
-      1,
-      { clientId: 'test-client-id' }
-    )
     // Receipt, warning, and developer metrics should NOT be logged
     expect(metrics.logReceiptMetrics).not.toHaveBeenCalled()
     expect(metrics.logWarningMetrics).not.toHaveBeenCalled()
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
-    expect(metrics.metricsCounter).toHaveBeenCalledTimes(4)
+    expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     expect(mockH.code).toHaveBeenCalledWith(400)
   })
 })

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ import { setupProxy } from './common/helpers/proxy/setup-proxy.js'
 import { swagger } from './plugins/swagger.js'
 import { errorHandler } from './plugins/error-handler.js'
 import { jwtAuth } from './plugins/jwt-auth.js'
+import { requestMetrics } from './plugins/request-metrics.js'
 import { createLogger } from './common/helpers/logging/logger.js'
 
 async function createServer() {
@@ -94,7 +95,8 @@ async function createServer() {
     requestTracing,
     secureContext,
     pulse,
-    errorHandler
+    errorHandler,
+    requestMetrics
   ])
 
   return server


### PR DESCRIPTION
### Description
Ticket [DWTA-223](https://eaflood.atlassian.net/browse/DWTA-223) 
and
Ticket [DWTA-197](https://eaflood.atlassian.net/browse/DWTA-197) 

Implemented the `requestMetrics` plugin to track developer activity for receipt movement endpoints. Key updates include:

- Added a helper function, `isReceiptMovementEndpoint`, to identify relevant routes.
- Introduced per-client `developers.attempted` metrics for receipt movement requests.
- Enhanced validation error, warning, and receipt metrics with `clientId` dimensions.
- Extended test coverage across plugins, handlers, and routes to ensure consistent metrics behavior.
- Refactored `logReceiptMetrics` and `logWarningMetrics` for `clientId`-scoped metric logging.


[DWTA-223]: https://eaflood.atlassian.net/browse/DWTA-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DWTA-197]: https://eaflood.atlassian.net/browse/DWTA-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ