### PR TITLE
DWT-213/253 Update waste-movement-utils to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "pino-pretty": "13.0.0",
         "undici": "7.24.5",
         "uuid": "13.0.2",
-        "waste-movement-utils": "github:DEFRA/waste-movement-utils#f2e83301e099390f26f8e484ec26ecfa2b60895e"
+        "waste-movement-utils": "github:DEFRA/waste-movement-utils#a479432f6f7c5808ca9f2e6d2a0abe473a3506e6"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -11759,14 +11759,11 @@
     },
     "node_modules/waste-movement-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#f2e83301e099390f26f8e484ec26ecfa2b60895e",
-      "integrity": "sha512-uOrJKwLellRq39pSNrvHYKStzj8IU9PjBwztplcIfqvUOmq5ImSlmhMvYq5UhgzMe0l36s7nsbZzo9KPDgQVxg==",
+      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#a479432f6f7c5808ca9f2e6d2a0abe473a3506e6",
+      "integrity": "sha512-HTEL546MMXOOjWt1+bW+XFKQqNyhVs4F6LzXSHKDCm0uR4EzmeWxMqgrn1Mdq71r05etvEezBHagvtxJYk4PIQ==",
       "license": "OGL-UK-3.0",
       "engines": {
         "node": ">=22"
-      },
-      "peerDependencies": {
-        "joi": "^17.13.3"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pino-pretty": "13.0.0",
     "undici": "7.24.5",
     "uuid": "13.0.2",
-    "waste-movement-utils": "github:DEFRA/waste-movement-utils#f2e83301e099390f26f8e484ec26ecfa2b60895e"
+    "waste-movement-utils": "github:DEFRA/waste-movement-utils#a479432f6f7c5808ca9f2e6d2a0abe473a3506e6"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",


### PR DESCRIPTION
Tickets [DWTA-213](https://eaflood.atlassian.net/browse/DWTA-213) and [DWTA-253](https://eaflood.atlassian.net/browse/DWTA-253)

This change updates `waste-movement-utils` to the latest version to use the new regexes for Carrier Registration Number and Site Authorisation Number validation

[DWTA-253]: https://eaflood.atlassian.net/browse/DWTA-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DWTA-213]: https://eaflood.atlassian.net/browse/DWTA-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ