### PR TITLE
DWTA-213 Update waste-movement-utils version for updated SEPA Carrier Registration Number validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
         "node-fetch": "3.3.2",
         "pino": "9.5.0",
         "pino-pretty": "13.0.0",
-        "undici": "7.24.5",
+        "undici": "7.28.0",
         "uuid": "13.0.2",
-        "waste-movement-utils": "github:DEFRA/waste-movement-utils#a479432f6f7c5808ca9f2e6d2a0abe473a3506e6"
+        "waste-movement-utils": "github:DEFRA/waste-movement-utils#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -11561,9 +11561,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -11759,8 +11759,8 @@
     },
     "node_modules/waste-movement-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#a479432f6f7c5808ca9f2e6d2a0abe473a3506e6",
-      "integrity": "sha512-HTEL546MMXOOjWt1+bW+XFKQqNyhVs4F6LzXSHKDCm0uR4EzmeWxMqgrn1Mdq71r05etvEezBHagvtxJYk4PIQ==",
+      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0",
+      "integrity": "sha512-qW3r2tc+ZasqecV84AWU7MzJtkfUQaDfhNIMyvE/7QpFXOUATk6NbZPQ/LuHbD4+eZOfMDG6TDHAwWpXCmVVzw==",
       "license": "OGL-UK-3.0",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node-fetch": "3.3.2",
     "pino": "9.5.0",
     "pino-pretty": "13.0.0",
-    "undici": "7.24.5",
+    "undici": "7.28.0",
     "uuid": "13.0.2",
     "waste-movement-utils": "github:DEFRA/waste-movement-utils#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pino-pretty": "13.0.0",
     "undici": "7.24.5",
     "uuid": "13.0.2",
-    "waste-movement-utils": "github:DEFRA/waste-movement-utils#a479432f6f7c5808ca9f2e6d2a0abe473a3506e6"
+    "waste-movement-utils": "github:DEFRA/waste-movement-utils#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",


### PR DESCRIPTION
Ticket [DWTA-213](https://eaflood.atlassian.net/browse/DWTA-213)

This change updates `waste-movement-utils` to use the updated SEPA Carrier Registration Number validation.

Also update `undici` to fix vulnerabilities.

[DWTA-213]: https://eaflood.atlassian.net/browse/DWTA-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ