### PR TITLE
DWTA-276 Update waste movement utilities to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "pino-pretty": "13.0.0",
         "undici": "7.28.0",
         "uuid": "13.0.2",
-        "waste-movement-utils": "github:DEFRA/waste-movement-utils#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0"
+        "waste-movement-utils": "github:DEFRA/waste-movement-utils#dee757b63b923d995113bbf9b96fb2227bee877b"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -11759,8 +11759,8 @@
     },
     "node_modules/waste-movement-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0",
-      "integrity": "sha512-qW3r2tc+ZasqecV84AWU7MzJtkfUQaDfhNIMyvE/7QpFXOUATk6NbZPQ/LuHbD4+eZOfMDG6TDHAwWpXCmVVzw==",
+      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#dee757b63b923d995113bbf9b96fb2227bee877b",
+      "integrity": "sha512-ZA6lc8zbD5iV7h592Hf3veH/a7kJQGbtA0j+NTofAQgwrtEH9uybygSgiK1jctWpnXpbs5ZndGR5uEH48qGFfw==",
       "license": "OGL-UK-3.0",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pino-pretty": "13.0.0",
     "undici": "7.28.0",
     "uuid": "13.0.2",
-    "waste-movement-utils": "github:DEFRA/waste-movement-utils#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0"
+    "waste-movement-utils": "github:DEFRA/waste-movement-utils#dee757b63b923d995113bbf9b96fb2227bee877b"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/src/schemas/receive-movement-input.test.js
+++ b/src/schemas/receive-movement-input.test.js
@@ -28,7 +28,11 @@ describe('receiveMovementInputSchema', () => {
 
   it('should still apply the shared consignment custom validation', () => {
     const payload = createTestPayload({
-      wasteItemOverrides: { ewcCodes: ['180103'], containsHazardous: true }
+      wasteItemOverrides: {
+        ewcCodes: ['180103'],
+        containsHazardous: true,
+        hazardous: { sourceOfComponents: 'NOT_PROVIDED', hazCodes: ['HP_1'] }
+      }
     })
     delete payload.hazardousWasteConsignmentCode
     delete payload.reasonForNoConsignmentCode


### PR DESCRIPTION
### Description
Ticket [DWTA-276](https://eaflood.atlassian.net/browse/DWTA-276)

Updated the `waste-movement-utils` library to its latest version. Adjusted the test payload structure to include details for hazardous waste, ensuring compatibility with the updated utility.

[DWTA-276]: https://eaflood.atlassian.net/browse/DWTA-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ