### PR TITLE
DWTA-288 Return 402 Payment Required Response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "pino-pretty": "13.0.0",
         "undici": "7.28.0",
         "uuid": "13.0.2",
-        "waste-movement-utils": "github:DEFRA/waste-movement-utils#dee757b63b923d995113bbf9b96fb2227bee877b"
+        "waste-movement-utils": "github:DEFRA/waste-movement-utils#7cc6f95b459c8feb4be6240c901d95e1f763f0c2"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -2116,6 +2116,16 @@
       "integrity": "sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/basic": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/basic/-/basic-7.0.2.tgz",
+      "integrity": "sha512-kdpsmCEHVDlIYStRbszSyy/9+dq5KkfWLX5AjuHGPwtzuuZopZnhkVvMZV45hQ8hA8V/weCoMs0nzXJ7JCA2ow==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
       }
     },
@@ -11928,11 +11938,29 @@
     },
     "node_modules/waste-movement-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#dee757b63b923d995113bbf9b96fb2227bee877b",
-      "integrity": "sha512-ZA6lc8zbD5iV7h592Hf3veH/a7kJQGbtA0j+NTofAQgwrtEH9uybygSgiK1jctWpnXpbs5ZndGR5uEH48qGFfw==",
+      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#7cc6f95b459c8feb4be6240c901d95e1f763f0c2",
+      "integrity": "sha512-IWTp1/LOPkXDgZg3LHwRLOxxCiL6no2xtpX+Ojx3QKXcOXt7oOfFRZyRePi1BbogBXWw7X2m4y/piRdh2mEcYQ==",
       "license": "OGL-UK-3.0",
+      "dependencies": {
+        "@hapi/basic": "^7.0.2",
+        "joi": "18.2.1",
+        "uuid": "^14.0.0"
+      },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/waste-movement-utils/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pino-pretty": "13.0.0",
     "undici": "7.28.0",
     "uuid": "13.0.2",
-    "waste-movement-utils": "github:DEFRA/waste-movement-utils#dee757b63b923d995113bbf9b96fb2227bee877b"
+    "waste-movement-utils": "github:DEFRA/waste-movement-utils#7cc6f95b459c8feb4be6240c901d95e1f763f0c2"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/src/common/helpers/errors/payment-required-error.js
+++ b/src/common/helpers/errors/payment-required-error.js
@@ -1,0 +1,9 @@
+import { HTTP_STATUS } from 'waste-movement-utils'
+
+export class PaymentRequiredError extends Error {
+  constructor(message = 'Payment Required') {
+    super(message)
+    this.name = 'PaymentRequiredError'
+    this.statusCode = HTTP_STATUS.PAYMENT_REQUIRED
+  }
+}

--- a/src/common/helpers/errors/payment-required-error.test.js
+++ b/src/common/helpers/errors/payment-required-error.test.js
@@ -1,0 +1,24 @@
+import { HTTP_STATUS } from 'waste-movement-utils'
+import { PaymentRequiredError } from './payment-required-error.js'
+
+function basePaymentRequiredErrorChecks(error) {
+  expect(error).toBeInstanceOf(PaymentRequiredError)
+  expect(error.name).toEqual('PaymentRequiredError')
+  expect(error.statusCode).toEqual(HTTP_STATUS.PAYMENT_REQUIRED)
+}
+
+describe('PaymentRequiredError', () => {
+  it('should create a Payment Required Error with the default message', () => {
+    const error = new PaymentRequiredError()
+
+    basePaymentRequiredErrorChecks(error)
+    expect(error.message).toEqual('Payment Required')
+  })
+
+  it('should create a Payment Required Error with a custom message', () => {
+    const error = new PaymentRequiredError('Payment is required')
+
+    basePaymentRequiredErrorChecks(error)
+    expect(error.message).toEqual('Payment is required')
+  })
+})

--- a/src/common/helpers/handle-error-response.js
+++ b/src/common/helpers/handle-error-response.js
@@ -1,0 +1,21 @@
+import Boom from '@hapi/boom'
+import { PaymentRequiredError } from './errors/payment-required-error.js'
+
+/**
+ * Detects the type of error and throws a relevent Boom error.
+ *
+ * @param {Object} error - The error
+ *
+ * @returns {void}
+ */
+export function handleErrorResponse(error) {
+  if (error instanceof PaymentRequiredError) {
+    throw Boom.paymentRequired(error.message)
+  }
+
+  if (error.name === 'NotFoundError') {
+    throw Boom.notFound('Movement not found')
+  }
+
+  throw Boom.internal(error.message)
+}

--- a/src/common/helpers/handle-error-response.test.js
+++ b/src/common/helpers/handle-error-response.test.js
@@ -1,0 +1,29 @@
+import Boom from '@hapi/boom'
+import { PaymentRequiredError } from './errors/payment-required-error'
+import { handleErrorResponse } from './handle-error-response.js'
+
+describe('#handleErrorResponse', () => {
+  it('should throw a Payment Required Error', () => {
+    const error = new PaymentRequiredError('Payment is required')
+
+    expect(() => handleErrorResponse(error)).toThrowError(
+      Boom.paymentRequired('Payment is required')
+    )
+  })
+
+  it('should throw a Not Found Error', () => {
+    const error = { name: 'NotFoundError' }
+
+    expect(() => handleErrorResponse(error)).toThrowError(
+      Boom.notFound('Movement not found')
+    )
+  })
+
+  it('should throw an Internal Server Error', () => {
+    const error = { message: 'API Error' }
+
+    expect(() => handleErrorResponse(error)).toThrowError(
+      Boom.internal('API Error')
+    )
+  })
+})

--- a/src/common/helpers/submitting-organisation.js
+++ b/src/common/helpers/submitting-organisation.js
@@ -1,4 +1,6 @@
+import { HTTP_STATUS } from 'waste-movement-utils'
 import { httpClients } from './http-client.js'
+import { PaymentRequiredError } from './errors/payment-required-error.js'
 
 /**
  * Gets the Defra Customer Organisation Id from the Waste Organisation Backend based
@@ -14,16 +16,20 @@ import { httpClients } from './http-client.js'
 export async function addSubmittingOrganisationToRequest(requestData) {
   const { apiCode, ...movementWithoutApiCode } = requestData.movement
 
-  const submittingOrganisation = await httpClients.wasteOrganisation
+  const wasteOrganisationResponse = await httpClients.wasteOrganisation
     .get(`/organisation/${apiCode}`)
     .then(({ payload }) => payload)
 
-  if (submittingOrganisation?.defraCustomerOrganisationId) {
+  if (wasteOrganisationResponse.statusCode === HTTP_STATUS.PAYMENT_REQUIRED) {
+    throw new PaymentRequiredError(wasteOrganisationResponse.message)
+  }
+
+  if (wasteOrganisationResponse?.defraCustomerOrganisationId) {
     requestData.movement = {
       ...movementWithoutApiCode,
       submittingOrganisation: {
         defraCustomerOrganisationId:
-          submittingOrganisation.defraCustomerOrganisationId
+          wasteOrganisationResponse.defraCustomerOrganisationId
       }
     }
   }

--- a/src/common/helpers/submitting-organisation.test.js
+++ b/src/common/helpers/submitting-organisation.test.js
@@ -15,6 +15,12 @@ jest.mock('./http-client.js', () => ({
             statusCode: 404
           }
         })
+        .mockResolvedValueOnce({
+          payload: {
+            statusCode: 402,
+            message: 'Payment is required'
+          }
+        })
     }
   }
 }))
@@ -53,6 +59,15 @@ describe('submitting-organisation', () => {
       expect(result).toEqual({
         movement: requestData.movement
       })
+    })
+
+    it('should throw an error when a 402 Payment Required response is received from Waste Organisation Backend', async () => {
+      await expect(() =>
+        addSubmittingOrganisationToRequest({
+          ...requestData,
+          movement: { ...requestData.movement }
+        })
+      ).rejects.toThrowError('Payment is required')
     })
   })
 })

--- a/src/handlers/create-receipt-movement.js
+++ b/src/handlers/create-receipt-movement.js
@@ -81,6 +81,6 @@ export const handleCreateReceiptMovement = async (request, h) => {
     return handleBackendResponse(response, h, () => responseData)
   } catch (error) {
     logger.error({ error }, 'Error creating waste movement')
-    handleErrorResponse(error)
+    return handleErrorResponse(error)
   }
 }

--- a/src/handlers/create-receipt-movement.js
+++ b/src/handlers/create-receipt-movement.js
@@ -14,6 +14,7 @@ import {
   logDeveloperMetrics
 } from '../common/helpers/metrics.js'
 import { addSubmittingOrganisationToRequest } from '../common/helpers/submitting-organisation.js'
+import { handleErrorResponse } from '../common/helpers/handle-error-response.js'
 
 const logger = createLogger()
 
@@ -79,12 +80,7 @@ export const handleCreateReceiptMovement = async (request, h) => {
 
     return handleBackendResponse(response, h, () => responseData)
   } catch (error) {
-    logger.error({ err: error }, 'Error creating waste movement')
-    return h
-      .response({
-        error: 'Internal Server Error',
-        message: 'Failed to create waste movement'
-      })
-      .code(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    logger.error({ error }, 'Error creating waste movement')
+    handleErrorResponse(error)
   }
 }

--- a/src/handlers/create-receipt-movement.test.js
+++ b/src/handlers/create-receipt-movement.test.js
@@ -3,6 +3,7 @@ import { httpClients } from '../common/helpers/http-client.js'
 import { handleCreateReceiptMovement } from './create-receipt-movement.js'
 import { v4 as uuidv4 } from 'uuid'
 import * as metrics from '../common/helpers/metrics.js'
+import Boom from '@hapi/boom'
 
 // Mock the httpClients
 jest.mock('../common/helpers/http-client.js', () => ({
@@ -215,7 +216,7 @@ describe('Create Receipt Movement Handler', () => {
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
   })
 
-  it('should return 500 when waste movement creation fails', async () => {
+  it('should throw a 500 error when waste movement creation fails', async () => {
     // Mock waste movement creation failure
     httpClients.wasteMovement.post.mockRejectedValue(new Error('API Error'))
 
@@ -224,16 +225,12 @@ describe('Create Receipt Movement Handler', () => {
       code: jest.fn().mockReturnThis()
     }
 
-    await handleCreateReceiptMovement(request, h)
-
-    expect(h.response).toHaveBeenCalledWith({
-      error: 'Internal Server Error',
-      message: 'Failed to create waste movement'
-    })
-    expect(h.code).toHaveBeenCalledWith(500)
+    await expect(() => handleCreateReceiptMovement(request, h)).rejects.toThrow(
+      Boom.internal('API Error')
+    )
   })
 
-  it('should return 500 when waste tracking ID request fails', async () => {
+  it('should throw a 500 error when waste tracking ID request fails', async () => {
     // Mock waste tracking ID request failure
     httpClients.wasteTracking.get.mockRejectedValue(new Error('API Error'))
 
@@ -242,13 +239,9 @@ describe('Create Receipt Movement Handler', () => {
       code: jest.fn().mockReturnThis()
     }
 
-    await handleCreateReceiptMovement(request, h)
-
-    expect(h.response).toHaveBeenCalledWith({
-      error: 'Internal Server Error',
-      message: 'Failed to create waste movement'
-    })
-    expect(h.code).toHaveBeenCalledWith(500)
+    await expect(() => handleCreateReceiptMovement(request, h)).rejects.toThrow(
+      Boom.internal('API Error')
+    )
   })
 
   it('should not log developer metrics when clientId is not provided', async () => {
@@ -312,5 +305,24 @@ describe('Create Receipt Movement Handler', () => {
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
     expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     expect(h.code).toHaveBeenCalledWith(400)
+  })
+
+  it('should throw an error when a 402 Payment Required response is received from Waste Organisation Backend', async () => {
+    // Mock successful waste movement creation
+    httpClients.wasteOrganisation.get.mockResolvedValue({
+      payload: {
+        statusCode: 402,
+        message: 'Payment is required'
+      }
+    })
+
+    const h = {
+      response: jest.fn().mockReturnThis(),
+      code: jest.fn().mockReturnThis()
+    }
+
+    await expect(() => handleCreateReceiptMovement(request, h)).rejects.toThrow(
+      Boom.internal('Payment is required')
+    )
   })
 })

--- a/src/handlers/update-receipt-movement.js
+++ b/src/handlers/update-receipt-movement.js
@@ -75,6 +75,6 @@ export const handleUpdateReceiptMovement = async (request, h) => {
     return handleBackendResponse(response, h, () => responseData)
   } catch (error) {
     logger.error({ error }, 'Error updating waste movement')
-    handleErrorResponse(error)
+    return handleErrorResponse(error)
   }
 }

--- a/src/handlers/update-receipt-movement.js
+++ b/src/handlers/update-receipt-movement.js
@@ -1,4 +1,3 @@
-import Boom from '@hapi/boom'
 import { httpClients } from '../common/helpers/http-client.js'
 import { handleBackendResponse } from './handle-backend-response.js'
 import {
@@ -14,6 +13,7 @@ import {
 import { isSuccessStatusCode } from '../common/helpers/utils.js'
 import { addSubmittingOrganisationToRequest } from '../common/helpers/submitting-organisation.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
+import { handleErrorResponse } from '../common/helpers/handle-error-response.js'
 
 const logger = createLogger()
 
@@ -74,9 +74,7 @@ export const handleUpdateReceiptMovement = async (request, h) => {
 
     return handleBackendResponse(response, h, () => responseData)
   } catch (error) {
-    if (error.name === 'NotFoundError') {
-      throw Boom.notFound('Movement not found')
-    }
-    throw Boom.internal(error.message)
+    logger.error({ error }, 'Error updating waste movement')
+    handleErrorResponse(error)
   }
 }

--- a/src/routes/create-receipt-movement.test.js
+++ b/src/routes/create-receipt-movement.test.js
@@ -4,6 +4,7 @@ import { createReceiptMovement } from './create-receipt-movement.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
 import { HTTP_STATUS } from 'waste-movement-utils'
 import * as metrics from '../common/helpers/metrics.js'
+import Boom from '@hapi/boom'
 
 // Mock the httpClients
 jest.mock('../common/helpers/http-client.js', () => ({
@@ -133,7 +134,7 @@ describe('Create Receipt Movement Route', () => {
     expect(forwardedMovement).not.toHaveProperty('clientId')
   })
 
-  it('should return 500 when waste movement creation fails', async () => {
+  it('should throw a 500 error when waste movement creation fails', async () => {
     // Mock waste movement creation failure
     httpClients.wasteMovement.post.mockRejectedValue(new Error('API Error'))
 
@@ -150,16 +151,12 @@ describe('Create Receipt Movement Route', () => {
       code: jest.fn().mockReturnThis()
     }
 
-    await createReceiptMovement.handler(request, h)
-
-    expect(h.response).toHaveBeenCalledWith({
-      error: 'Internal Server Error',
-      message: 'Failed to create waste movement'
-    })
-    expect(h.code).toHaveBeenCalledWith(500)
+    await expect(() =>
+      createReceiptMovement.handler(request, h)
+    ).rejects.toThrow(Boom.internal('API Error'))
   })
 
-  it('should return 500 when waste tracking ID request fails', async () => {
+  it('should throw a 500 error when waste tracking ID request fails', async () => {
     // Mock waste tracking ID request failure
     httpClients.wasteTracking.get.mockRejectedValue(new Error('API Error'))
 
@@ -176,12 +173,35 @@ describe('Create Receipt Movement Route', () => {
       code: jest.fn().mockReturnThis()
     }
 
-    await createReceiptMovement.handler(request, h)
+    await expect(() =>
+      createReceiptMovement.handler(request, h)
+    ).rejects.toThrow(Boom.internal('API Error'))
+  })
 
-    expect(h.response).toHaveBeenCalledWith({
-      error: 'Internal Server Error',
-      message: 'Failed to create waste movement'
+  it('should throw an error when a 402 Payment Required response is received from Waste Organisation Backend', async () => {
+    // Mock successful waste movement creation
+    httpClients.wasteOrganisation.get.mockResolvedValue({
+      payload: {
+        statusCode: 402,
+        message: 'Payment is required'
+      }
     })
-    expect(h.code).toHaveBeenCalledWith(500)
+
+    const request = {
+      auth: {
+        credentials: {
+          clientId: 'test-client-id'
+        }
+      },
+      payload: validPayload
+    }
+    const h = {
+      response: jest.fn().mockReturnThis(),
+      code: jest.fn().mockReturnThis()
+    }
+
+    await expect(() =>
+      createReceiptMovement.handler(request, h)
+    ).rejects.toThrow(Boom.internal('Payment is required'))
   })
 })

--- a/src/routes/disposal-recovery-codes.test.js
+++ b/src/routes/disposal-recovery-codes.test.js
@@ -3,6 +3,7 @@ import { httpClients } from '../common/helpers/http-client.js'
 import { createReceiptMovement } from './create-receipt-movement.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
 import { HTTP_STATUS } from 'waste-movement-utils'
+import Boom from '@hapi/boom'
 
 // Mock the httpClients
 jest.mock('../common/helpers/http-client.js', () => ({
@@ -189,12 +190,9 @@ describe('Create Receipt Movement - Disposal/Recovery Code Handler', () => {
           code: jest.fn().mockReturnThis()
         }
 
-        await createReceiptMovement.handler(request, h)
-
-        expect(h.response).toHaveBeenCalledWith({
-          error: 'Internal Server Error',
-          message: 'Failed to create waste movement'
-        })
+        await expect(() =>
+          createReceiptMovement.handler(request, h)
+        ).rejects.toThrow(Boom.internal('Backend Error'))
       })
     })
   })

--- a/src/routes/means-of-transport.test.js
+++ b/src/routes/means-of-transport.test.js
@@ -3,6 +3,7 @@ import { httpClients } from '../common/helpers/http-client.js'
 import { createReceiptMovement } from './create-receipt-movement.js'
 import { v4 as uuidv4 } from 'uuid'
 import { HTTP_STATUS } from 'waste-movement-utils'
+import Boom from '@hapi/boom'
 
 // Mock the httpClients
 jest.mock('../common/helpers/http-client.js', () => ({
@@ -207,12 +208,9 @@ describe('Create Receipt Movement - Means of Transport Handler', () => {
           code: jest.fn().mockReturnThis()
         }
 
-        await createReceiptMovement.handler(request, h)
-
-        expect(h.response).toHaveBeenCalledWith({
-          error: 'Internal Server Error',
-          message: 'Failed to create waste movement'
-        })
+        await expect(() =>
+          createReceiptMovement.handler(request, h)
+        ).rejects.toThrow(Boom.internal('Backend Error'))
       })
     })
   })


### PR DESCRIPTION
Ticket [DWTA-288](https://eaflood.atlassian.net/browse/DWTA-288)

This change proxies a 402 Payment Required response from the Waste Organisation Backend.

Changes:
- Update `waste-movement-utils` dependency to the latest version so we can use the new `HTTP_STATUS.PAYMENT_REQUIRED` constant.
- Add a `PaymentRequiredError` class, which is used to make it easier to distinguish a 402 when throwing an error response and this ensures that the error message from the Waste Organisation Backend is also proxied through.
- Refactor the Create Movement flow to throw a `Boom` error as happens in the Update Movement flow and create a `handleErrorResponse()` helper function to use in both flows.
- Update existing unit tests to reflect the changfe from returning an error to throwing it and add new unit tests to check the 402 is handled correctly.

[DWTA-288]: https://eaflood.atlassian.net/browse/DWTA-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ