### PR TITLE
DWTA-337 Remove local environment check in waste-movement-external-api

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -96,9 +96,13 @@ jobs:
           WASTE_MOVEMENT_BACKEND_API_BASE_URL: http://waste-movement-backend:3001
           WASTE_ORGANISATION_BACKEND_API_BASE_URL: http://waste-organisation-backend:3001
           HTTP_PROXY: http://localhost:8080
-          PROXY_MODE: zap
+          PROXY_MODE: ${{ vars.PROXY_MODE }}
           ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
-          AUTH_DISABLED: true
+          AUTH_DISABLED: ${{ vars.AUTH_DISABLED }}
+          COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
+          COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
+          COGNITO_OAUTH_BASE_URL: ${{ secrets.COGNITO_OAUTH_BASE_URL }}
+          ENVIRONMENT: ${{ vars.ENVIRONMENT }}
           API_LOGGING: true
           JIRA_BASE_URL: https://eaflood.atlassian.net/browse
           PROFILE: integration

--- a/src/common/helpers/start-server.test.js
+++ b/src/common/helpers/start-server.test.js
@@ -118,32 +118,12 @@ describe('#startServer', () => {
       ])
     })
 
-    test('Should start with jwt auth disabled in local environment', async () => {
-      // process.env.ENVIRONMENT = 'local' // Ensure we're in local mode
+    test('Should register jwt auth regardless of environment (DWTA-337)', async () => {
       config.load({
         cdpEnvironment: 'local'
       })
       await startServerImport.startServer()
 
-      expect(mockServer.register).toHaveBeenCalledWith(expect.any(Array))
-      expect(mockServer.register).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          plugin: {
-            name: 'jwt-auth',
-            register: expect.any(Function)
-          }
-        })
-      )
-    })
-
-    test.skip('Should start with jwt auth enabled in non-local environment', async () => {
-      // process.env.ENVIRONMENT = 'prod' // Ensure we're in non-local mode
-      config.load({
-        cdpEnvironment: 'prod'
-      })
-      await startServerImport.startServer()
-
-      expect(mockServer.register).toHaveBeenCalledWith(expect.any(Array))
       expect(mockServer.register).toHaveBeenCalledWith(
         expect.objectContaining({
           plugin: {

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -4,7 +4,8 @@ import * as metrics from '../common/helpers/metrics.js'
 import { httpClients } from '../common/helpers/http-client.js'
 
 jest.mock('../common/helpers/metrics.js', () => ({
-  metricsCounter: jest.fn()
+  metricsCounter: jest.fn(),
+  logAttemptedDeveloperMetrics: jest.fn()
 }))
 
 jest.mock('../common/helpers/http-client.js', () => ({
@@ -21,6 +22,28 @@ jest.mock('../common/helpers/http-client.js', () => ({
           defraCustomerOrganisationId: 'd829f66d-857f-401d-b5e9-5061b7dbb29d'
         }
       })
+    }
+  }
+}))
+
+// The receive routes require authentication (DWTA-337 removed the local-env
+// bypass), so stub jwt-auth with a scheme that authenticates with empty
+// credentials (no clientId). Tests that need a clientId inject one via their own
+// onPostAuth hook (see the ClientId-scoped metrics block); the rest assert the
+// no-clientId dimension sets.
+jest.mock('./jwt-auth.js', () => ({
+  jwtAuth: {
+    plugin: {
+      name: 'jwt-auth',
+      register(server) {
+        server.auth.scheme('jwt', () => ({
+          authenticate(request, h) {
+            return h.authenticated({ credentials: {} })
+          }
+        }))
+        server.auth.strategy('jwt', 'jwt')
+        server.auth.default('jwt')
+      }
     }
   }
 }))

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -4,8 +4,7 @@ import * as metrics from '../common/helpers/metrics.js'
 import { httpClients } from '../common/helpers/http-client.js'
 
 jest.mock('../common/helpers/metrics.js', () => ({
-  metricsCounter: jest.fn(),
-  logAttemptedDeveloperMetrics: jest.fn()
+  metricsCounter: jest.fn()
 }))
 
 jest.mock('../common/helpers/http-client.js', () => ({
@@ -22,28 +21,6 @@ jest.mock('../common/helpers/http-client.js', () => ({
           defraCustomerOrganisationId: 'd829f66d-857f-401d-b5e9-5061b7dbb29d'
         }
       })
-    }
-  }
-}))
-
-// The receive routes require authentication (DWTA-337 removed the local-env
-// bypass), so stub jwt-auth with a scheme that authenticates with empty
-// credentials (no clientId). Tests that need a clientId inject one via their own
-// onPostAuth hook (see the ClientId-scoped metrics block); the rest assert the
-// no-clientId dimension sets.
-jest.mock('./jwt-auth.js', () => ({
-  jwtAuth: {
-    plugin: {
-      name: 'jwt-auth',
-      register(server) {
-        server.auth.scheme('jwt', () => ({
-          authenticate(request, h) {
-            return h.authenticated({ credentials: {} })
-          }
-        }))
-        server.auth.strategy('jwt', 'jwt')
-        server.auth.default('jwt')
-      }
     }
   }
 }))

--- a/src/server.js
+++ b/src/server.js
@@ -15,7 +15,6 @@ import { errorHandler } from './plugins/error-handler.js'
 import { jwtAuth } from './plugins/jwt-auth.js'
 import { requestMetrics } from './plugins/request-metrics.js'
 import { clientContext } from './common/helpers/client-context.js'
-import { createLogger } from './common/helpers/logging/logger.js'
 
 async function createServer() {
   setupProxy()
@@ -76,16 +75,10 @@ async function createServer() {
   // Register Swagger before routes
   await server.register(swagger)
 
-  const logger = createLogger()
-
-  // Register JWT authentication before routes
-  if (config.get('cdpEnvironment') === 'local') {
-    logger.error(
-      'WARNING: Local environment detected. JWT authentication is disabled.'
-    )
-  } else {
-    await server.register(jwtAuth)
-  }
+  // Register JWT authentication before routes. It is always registered so the
+  // client id can be extracted from the JWT and forwarded to the backend,
+  // regardless of the environment the app runs in (see DWTA-337).
+  await server.register(jwtAuth)
 
   // Register routes
   await server.register(router)


### PR DESCRIPTION
### Description
Ticket [DWTA-337](https://eaflood.atlassian.net/browse/DWTA-337)

This pull request updates the JWT authentication process to ensure it registers in all environments, regardless of the specific environment settings.


[DWTA-337]: https://eaflood.atlassian.net/browse/DWTA-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ