### PR TITLE
DWTA-354 Add new fields into the logging

### DIFF
--- a/src/plugins/request-metrics.js
+++ b/src/plugins/request-metrics.js
@@ -33,7 +33,7 @@ export const requestMetrics = {
           request.logger.info(
             {
               client: clientId ? { id: clientId } : undefined,
-              organization: organisationId ? { id: organisationId } : undefined
+              organisation: organisationId ? { id: organisationId } : undefined
             },
             'Receipt movement attempted'
           )

--- a/src/plugins/request-metrics.js
+++ b/src/plugins/request-metrics.js
@@ -20,6 +20,27 @@ export const requestMetrics = {
         }
         return h.continue
       })
+
+      server.ext(
+        'onPostAuth',
+        (request, h) => {
+          if (!isReceiptMovementEndpoint(request)) {
+            return h.continue
+          }
+          const clientId = request.auth?.credentials?.clientId
+          const organisationId =
+            request.submittingOrganisation?.defraCustomerOrganisationId
+          request.logger.info(
+            {
+              client: clientId ? { id: clientId } : undefined,
+              organization: organisationId ? { id: organisationId } : undefined
+            },
+            'Receipt movement attempted'
+          )
+          return h.continue
+        },
+        { after: 'addSubmittingOrganisationToRequest' }
+      )
     }
   }
 }

--- a/src/plugins/request-metrics.test.js
+++ b/src/plugins/request-metrics.test.js
@@ -6,8 +6,26 @@ jest.mock('../common/helpers/metrics.js', () => ({
   logAttemptedDeveloperMetrics: jest.fn()
 }))
 
-const buildServer = async ({ withAuth }) => {
+const loggerInfo = jest.fn()
+
+const submittingOrganisationStub = {
+  plugin: {
+    name: 'addSubmittingOrganisationToRequest',
+    register: async (server) => {
+      server.ext('onPostAuth', (request, h) => {
+        request.submittingOrganisation = {
+          defraCustomerOrganisationId: 'test-org-id'
+        }
+        return h.continue
+      })
+    }
+  }
+}
+
+const buildServer = async ({ withAuth, withSubmittingOrganisation }) => {
   const server = Hapi.server()
+
+  server.decorate('request', 'logger', { info: loggerInfo })
 
   if (withAuth) {
     server.auth.scheme('mock', () => ({
@@ -37,7 +55,12 @@ const buildServer = async ({ withAuth }) => {
     }
   ])
 
+  // Mirror the registration order in server.js: requestMetrics first,
+  // addSubmittingOrganisationToRequest afterwards.
   await server.register(requestMetrics)
+  if (withSubmittingOrganisation) {
+    await server.register(submittingOrganisationStub)
+  }
   return server
 }
 
@@ -97,5 +120,57 @@ describe('requestMetrics plugin', () => {
     })
 
     expect(metrics.logAttemptedDeveloperMetrics).not.toHaveBeenCalled()
+  })
+
+  it('logs client and organisation ids for receipt movement attempts', async () => {
+    const server = await buildServer({
+      withAuth: true,
+      withSubmittingOrganisation: true
+    })
+
+    await server.inject({
+      method: 'POST',
+      url: '/movements/receive',
+      payload: {}
+    })
+
+    expect(loggerInfo).toHaveBeenCalledTimes(1)
+    expect(loggerInfo).toHaveBeenCalledWith(
+      {
+        client: { id: 'test-client-id' },
+        organization: { id: 'test-org-id' }
+      },
+      'Receipt movement attempted'
+    )
+  })
+
+  it('logs without organisation id when none is resolved', async () => {
+    const server = await buildServer({ withAuth: true })
+
+    await server.inject({
+      method: 'PUT',
+      url: '/movements/abc-123/receive',
+      payload: {}
+    })
+
+    expect(loggerInfo).toHaveBeenCalledTimes(1)
+    expect(loggerInfo).toHaveBeenCalledWith(
+      {
+        client: { id: 'test-client-id' },
+        organization: undefined
+      },
+      'Receipt movement attempted'
+    )
+  })
+
+  it('does not log attempts for non-receipt-movement routes', async () => {
+    const server = await buildServer({ withAuth: true })
+
+    await server.inject({
+      method: 'GET',
+      url: '/health'
+    })
+
+    expect(loggerInfo).not.toHaveBeenCalled()
   })
 })

--- a/src/plugins/request-metrics.test.js
+++ b/src/plugins/request-metrics.test.js
@@ -138,7 +138,7 @@ describe('requestMetrics plugin', () => {
     expect(loggerInfo).toHaveBeenCalledWith(
       {
         client: { id: 'test-client-id' },
-        organization: { id: 'test-org-id' }
+        organisation: { id: 'test-org-id' }
       },
       'Receipt movement attempted'
     )
@@ -157,7 +157,7 @@ describe('requestMetrics plugin', () => {
     expect(loggerInfo).toHaveBeenCalledWith(
       {
         client: { id: 'test-client-id' },
-        organization: undefined
+        organisation: undefined
       },
       'Receipt movement attempted'
     )


### PR DESCRIPTION
### Description
Ticket [DWTA-354](https://eaflood.atlassian.net/browse/DWTA-354)

- Enhanced the `requestMetrics` plugin to log client and organisation IDs during receipt movement attempts.

[DWTA-354]: https://eaflood.atlassian.net/browse/DWTA-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ