### PR TITLE
DWTA-354 Add new fields into the logging

### DIFF
--- a/src/plugins/request-metrics.js
+++ b/src/plugins/request-metrics.js
@@ -30,10 +30,18 @@ export const requestMetrics = {
           const clientId = request.auth?.credentials?.clientId
           const organisationId =
             request.submittingOrganisation?.defraCustomerOrganisationId
+          // CDP's log pipeline only indexes its allowlisted ECS fields
+          // (cdp-documentation how-to/logging.md), so the client id rides in
+          // tenant.id and the organisation id in event.reference. The
+          // pipeline drops flattened keys where nested are expected, so these
+          // must stay nested objects.
           request.logger.info(
             {
-              client: clientId ? { id: clientId } : undefined,
-              organisation: organisationId ? { id: organisationId } : undefined
+              tenant: clientId ? { id: clientId } : undefined,
+              event: {
+                reference: organisationId,
+                action: 'receipt-movement-attempted'
+              }
             },
             'Receipt movement attempted'
           )

--- a/src/plugins/request-metrics.test.js
+++ b/src/plugins/request-metrics.test.js
@@ -122,7 +122,7 @@ describe('requestMetrics plugin', () => {
     expect(metrics.logAttemptedDeveloperMetrics).not.toHaveBeenCalled()
   })
 
-  it('logs client and organisation ids for receipt movement attempts', async () => {
+  it('logs tenant and event reference ids for receipt movement attempts', async () => {
     const server = await buildServer({
       withAuth: true,
       withSubmittingOrganisation: true
@@ -137,14 +137,17 @@ describe('requestMetrics plugin', () => {
     expect(loggerInfo).toHaveBeenCalledTimes(1)
     expect(loggerInfo).toHaveBeenCalledWith(
       {
-        client: { id: 'test-client-id' },
-        organisation: { id: 'test-org-id' }
+        tenant: { id: 'test-client-id' },
+        event: {
+          reference: 'test-org-id',
+          action: 'receipt-movement-attempted'
+        }
       },
       'Receipt movement attempted'
     )
   })
 
-  it('logs without organisation id when none is resolved', async () => {
+  it('logs without an event reference when no organisation is resolved', async () => {
     const server = await buildServer({ withAuth: true })
 
     await server.inject({
@@ -156,8 +159,11 @@ describe('requestMetrics plugin', () => {
     expect(loggerInfo).toHaveBeenCalledTimes(1)
     expect(loggerInfo).toHaveBeenCalledWith(
       {
-        client: { id: 'test-client-id' },
-        organisation: undefined
+        tenant: { id: 'test-client-id' },
+        event: {
+          reference: undefined,
+          action: 'receipt-movement-attempted'
+        }
       },
       'Receipt movement attempted'
     )


### PR DESCRIPTION
### Description
Ticket [DWTA-354](https://eaflood.atlassian.net/browse/DWTA-354)

* Replace `client` and `organisation` IDs with `tenant` and `event` references to comply with CDP log pipeline requirements.
* Adjust test cases to validate the updated logging structure.

[DWTA-354]: https://eaflood.atlassian.net/browse/DWTA-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ