### PR TITLE
DWTA-343 Returning 500 reponse for malformed JSON in request body

### DIFF
--- a/src/plugins/error-handler.js
+++ b/src/plugins/error-handler.js
@@ -10,6 +10,18 @@ import {
 const withClientId = (dims, clientId) =>
   clientId ? { ...dims, clientId } : dims
 
+const formatPayloadParseError = (response) => ({
+  validation: {
+    errors: [
+      {
+        key: 'payload',
+        errorType: 'InvalidFormat',
+        message: response.output.payload.message
+      }
+    ]
+  }
+})
+
 export const errorHandler = {
   plugin: {
     name: 'errorHandler',
@@ -24,7 +36,9 @@ export const errorHandler = {
 
         // Check if it's a validation error (Boom error with status 400)
         if (response.isBoom && response.output.statusCode === 400) {
-          const customError = validationErrorFormatter(response, logger)
+          const customError = Array.isArray(response.details)
+            ? validationErrorFormatter(response, logger)
+            : formatPayloadParseError(response)
 
           // Log validation error metrics for receipt movement endpoints
           if (isReceiptMovementEndpoint(request)) {

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -321,6 +321,46 @@ describe('Error Handler', () => {
     }
   })
 
+  describe('Malformed JSON payload', () => {
+    test('should return 400 with validation error for invalid JSON escape sequence', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/movements/receive',
+        headers: { 'content-type': 'application/json' },
+        payload: '{"receiver":{"authorisationNumber":"po9099ci\\D12345"}}'
+      })
+
+      expect(response.statusCode).toBe(400)
+      const responseBody = JSON.parse(response.payload)
+
+      expect(responseBody).toEqual({
+        validation: {
+          errors: [
+            {
+              key: 'payload',
+              errorType: 'InvalidFormat',
+              message: 'Invalid request payload JSON format'
+            }
+          ]
+        }
+      })
+    })
+
+    test('should return 400 for structurally malformed JSON', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/movements/receive',
+        headers: { 'content-type': 'application/json' },
+        payload: '{"receiver" "value"}'
+      })
+
+      expect(response.statusCode).toBe(400)
+      const responseBody = JSON.parse(response.payload)
+
+      expect(responseBody.validation.errors[0].errorType).toBe('InvalidFormat')
+    })
+  })
+
   describe('Granular Error Categories', () => {
     test('should return InvalidType for wrong data type (string where number expected)', async () => {
       const basePayload = createMovementRequest()


### PR DESCRIPTION
### Description
Ticket [DWTA-343](https://eaflood.atlassian.net/browse/DWTA-343)

* Add validation for malformed JSON payloads, returning structured 400 responses with error details.
* Introduce `formatPayloadParseError` to process invalid JSON format errors.
* Update error handler logic to differentiate between schema validation and JSON parsing errors.
* Add tests for invalid JSON scenarios.

[DWTA-343]: https://eaflood.atlassian.net/browse/DWTA-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ