### PR TITLE
DWTA-357 Replace metrics with logging

### DIFF
--- a/src/common/helpers/metrics.js
+++ b/src/common/helpers/metrics.js
@@ -8,6 +8,8 @@ import { createLogger } from './logging/logger.js'
 import { normalizeArrayIndices } from './utils.js'
 import { METRIC_NAMES } from '@defra/waste-movement-utils'
 
+const logger = createLogger()
+
 /**
  * Logs a counter metric with optional dimensions
  * @param {string} metricName - Metric name (dot notation recommended)
@@ -32,7 +34,7 @@ const metricsCounter = async (metricName, value = 1, dimensions = {}) => {
     )
     await metricsLogger.flush()
   } catch (error) {
-    createLogger().error(error, error.message)
+    logger.error(error, error.message)
   }
 }
 
@@ -52,6 +54,7 @@ const logReceiptMetrics = async (endpointType, clientId) => {
     1,
     withClientId({ endpointType }, clientId)
   )
+  logger.info(`${METRIC_NAMES.RECEIPTS_RECEIVED} - ${endpointType}`)
 }
 
 /**
@@ -74,6 +77,7 @@ const logWarningMetrics = async (warnings, endpointType, clientId) => {
       1,
       baseDims
     )
+    logger.info(METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS)
 
     for (const warning of warnings) {
       const warningReason = normalizeArrayIndices(warning.message)
@@ -81,6 +85,9 @@ const logWarningMetrics = async (warnings, endpointType, clientId) => {
         ...baseDims,
         warningReason
       })
+      logger.info(
+        `${METRIC_NAMES.VALIDATION_WARNING_REASON} - ${warningReason}`
+      )
     }
   } else {
     await metricsCounter(
@@ -88,6 +95,7 @@ const logWarningMetrics = async (warnings, endpointType, clientId) => {
       1,
       baseDims
     )
+    logger.info(METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS)
   }
 }
 
@@ -98,6 +106,7 @@ const logWarningMetrics = async (warnings, endpointType, clientId) => {
  */
 const logDeveloperMetrics = async (clientId) => {
   await metricsCounter(METRIC_NAMES.DEVELOPERS_ACTIVE, 1, { clientId })
+  logger.info(METRIC_NAMES.DEVELOPERS_ACTIVE)
 }
 
 /**
@@ -108,6 +117,7 @@ const logDeveloperMetrics = async (clientId) => {
  * @param {string} clientId - The developer's client ID
  */
 const logAttemptedDeveloperMetrics = async (clientId) => {
+  logger.info(METRIC_NAMES.DEVELOPERS_ATTEMPTED)
   if (!clientId) {
     return
   }

--- a/src/common/helpers/metrics.test.js
+++ b/src/common/helpers/metrics.test.js
@@ -7,11 +7,13 @@ import {
   logReceiptMetrics,
   logAttemptedDeveloperMetrics
 } from './metrics.js'
+import { METRIC_NAMES } from '@defra/waste-movement-utils'
 
 const mockPutMetric = jest.fn()
 const mockPutDimensions = jest.fn()
 const mockFlush = jest.fn()
 const mockLoggerError = jest.fn()
+const mockLoggerInfo = jest.fn()
 
 jest.mock('aws-embedded-metrics', () => ({
   ...jest.requireActual('aws-embedded-metrics'),
@@ -22,7 +24,10 @@ jest.mock('aws-embedded-metrics', () => ({
   })
 }))
 jest.mock('./logging/logger.js', () => ({
-  createLogger: () => ({ error: (...args) => mockLoggerError(...args) })
+  createLogger: () => ({
+    error: (...args) => mockLoggerError(...args),
+    info: (...args) => mockLoggerInfo(...args)
+  })
 }))
 
 const mockMetricsName = 'mock-metrics-name'
@@ -155,6 +160,16 @@ describe('#logWarningMetrics', () => {
       endpointType: 'post',
       warningReason: '"wasteItems[*].weight.isEstimate" is missing'
     })
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS
+    )
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_WARNING_REASON} - "wasteItems[*].weight.metric" is missing`
+    )
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_WARNING_REASON} - "wasteItems[*].weight.isEstimate" is missing`
+    )
   })
 
   test('Should normalize array indices in warning messages', async () => {
@@ -174,6 +189,13 @@ describe('#logWarningMetrics', () => {
       warningReason:
         '"wasteItems[*].disposalOrRecoveryCodes[*].code" is missing'
     })
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      METRIC_NAMES.VALIDATION_REQUESTS_WITH_WARNINGS
+    )
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_WARNING_REASON} - "wasteItems[*].disposalOrRecoveryCodes[*].code" is missing`
+    )
   })
 
   test('Should not emit per-warning metrics when no warnings', async () => {
@@ -188,6 +210,10 @@ describe('#logWarningMetrics', () => {
     )
     expect(mockPutDimensions).not.toHaveBeenCalledWith(
       expect.objectContaining({ warningReason: expect.any(String) })
+    )
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_WARNINGS
     )
   })
 
@@ -257,6 +283,10 @@ describe('#logReceiptMetrics', () => {
       StorageResolution.Standard
     )
     expect(mockPutMetric).toHaveBeenCalledTimes(1)
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - post`
+    )
   })
 
   test('Should append clientId to dimensions when provided', async () => {
@@ -267,6 +297,10 @@ describe('#logReceiptMetrics', () => {
       clientId: 'test-client-id'
     })
     expect(mockPutDimensions).toHaveBeenCalledTimes(1)
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - post`
+    )
   })
 })
 
@@ -289,6 +323,10 @@ describe('#logAttemptedDeveloperMetrics', () => {
       StorageResolution.Standard
     )
     expect(mockPutMetric).toHaveBeenCalledTimes(1)
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      METRIC_NAMES.DEVELOPERS_ATTEMPTED
+    )
   })
 
   test('Should not emit when clientId is absent', async () => {

--- a/src/handlers/create-receipt-movement.js
+++ b/src/handlers/create-receipt-movement.js
@@ -70,6 +70,7 @@ export const handleCreateReceiptMovement = async (request, h) => {
       1,
       withoutErrorsDims
     )
+    logger.info(`${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - post`)
 
     // Only log metrics for successful responses
     if (isSuccess) {

--- a/src/handlers/create-receipt-movement.test.js
+++ b/src/handlers/create-receipt-movement.test.js
@@ -4,6 +4,8 @@ import { handleCreateReceiptMovement } from './create-receipt-movement.js'
 import { v4 as uuidv4 } from 'uuid'
 import * as metrics from '../common/helpers/metrics.js'
 import Boom from '@hapi/boom'
+import * as logger from '../common/helpers/logging/logger.js'
+import { METRIC_NAMES } from '@defra/waste-movement-utils'
 
 // Mock the httpClients
 jest.mock('../common/helpers/http-client.js', () => ({
@@ -103,6 +105,8 @@ describe('Create Receipt Movement Handler', () => {
       statusCode: 200
     })
 
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
+
     const h = {
       response: jest.fn().mockReturnThis(),
       code: jest.fn().mockReturnThis()
@@ -150,6 +154,10 @@ describe('Create Receipt Movement Handler', () => {
     )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - post`
+    )
   })
 
   it('should successfully create a waste movement with warnings and log metrics', async () => {
@@ -171,6 +179,8 @@ describe('Create Receipt Movement Handler', () => {
     httpClients.wasteMovement.post.mockResolvedValue({
       statusCode: 200
     })
+
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
 
     const h = {
       response: jest.fn().mockReturnThis(),
@@ -203,12 +213,18 @@ describe('Create Receipt Movement Handler', () => {
     )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - post`
+    )
   })
 
   it('should throw a 500 error when waste movement creation fails', async () => {
     // Mock waste movement creation failure
     httpClients.wasteMovement.post.mockRejectedValue(new Error('API Error'))
 
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
+
     const h = {
       response: jest.fn().mockReturnThis(),
       code: jest.fn().mockReturnThis()
@@ -217,12 +233,16 @@ describe('Create Receipt Movement Handler', () => {
     await expect(() => handleCreateReceiptMovement(request, h)).rejects.toThrow(
       Boom.internal('API Error')
     )
+
+    expect(infoLoggerSpy).not.toHaveBeenCalled()
   })
 
   it('should throw a 500 error when waste tracking ID request fails', async () => {
     // Mock waste tracking ID request failure
     httpClients.wasteTracking.get.mockRejectedValue(new Error('API Error'))
 
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
+
     const h = {
       response: jest.fn().mockReturnThis(),
       code: jest.fn().mockReturnThis()
@@ -231,6 +251,8 @@ describe('Create Receipt Movement Handler', () => {
     await expect(() => handleCreateReceiptMovement(request, h)).rejects.toThrow(
       Boom.internal('API Error')
     )
+
+    expect(infoLoggerSpy).not.toHaveBeenCalled()
   })
 
   it('should not log developer metrics when clientId is not provided', async () => {
@@ -275,6 +297,8 @@ describe('Create Receipt Movement Handler', () => {
       payload: { error: 'Bad Request' }
     })
 
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
+
     const h = {
       response: jest.fn().mockReturnThis(),
       code: jest.fn().mockReturnThis()
@@ -294,5 +318,9 @@ describe('Create Receipt Movement Handler', () => {
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
     expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     expect(h.code).toHaveBeenCalledWith(400)
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - post`
+    )
   })
 })

--- a/src/handlers/update-receipt-movement.js
+++ b/src/handlers/update-receipt-movement.js
@@ -65,6 +65,7 @@ export const handleUpdateReceiptMovement = async (request, h) => {
       1,
       withoutErrorsDims
     )
+    logger.info(`${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - put`)
 
     // Only log metrics for successful responses
     if (isSuccessStatusCode(response.statusCode)) {

--- a/src/plugins/error-handler.js
+++ b/src/plugins/error-handler.js
@@ -2,6 +2,7 @@ import { metricsCounter } from '../common/helpers/metrics.js'
 import { normalizeArrayIndices } from '../common/helpers/utils.js'
 import { isReceiptMovementEndpoint } from '../common/helpers/receipt-movement-endpoint.js'
 import {
+  HTTP_STATUS,
   METRIC_NAMES,
   validationErrorFormatter
 } from '@defra/waste-movement-utils'
@@ -26,87 +27,103 @@ export const errorHandler = {
   plugin: {
     name: 'errorHandler',
     register: async (server) => {
-      server.ext('onPreResponse', async (request, h) => {
-        const logger = request.logger
-        const response = request.response
-
-        if (response.isBoom) {
-          logger.error({ err: response }, 'Request error')
-        }
-
-        // Check if it's a validation error (Boom error with status 400)
-        if (response.isBoom && response.output.statusCode === 400) {
-          const customError = Array.isArray(response.details)
-            ? validationErrorFormatter(response, logger)
-            : formatPayloadParseError(response)
-
-          // Log validation error metrics for receipt movement endpoints
-          if (isReceiptMovementEndpoint(request)) {
-            const endpointType = request.method.toLowerCase()
-            const clientId = request.auth?.credentials?.clientId
-            const baseDims = withClientId({ endpointType }, clientId)
-
-            await metricsCounter(
-              METRIC_NAMES.VALIDATION_ERRORS_COUNT,
-              customError.validation.errors.length,
-              baseDims
-            )
-            await metricsCounter(
-              METRIC_NAMES.VALIDATION_REQUESTS_WITH_ERRORS,
-              1,
-              baseDims
-            )
-
-            for (const error of customError.validation.errors) {
-              const errorReason = normalizeArrayIndices(error.message)
-              await metricsCounter(METRIC_NAMES.VALIDATION_ERROR_REASON, 1, {
-                ...baseDims,
-                errorReason
-              })
-              await metricsCounter(METRIC_NAMES.VALIDATION_ERROR_CATEGORY, 1, {
-                ...baseDims,
-                errorCategory: error.errorType
-              })
-            }
-
-            await metricsCounter(METRIC_NAMES.ERRORS_BY_STATUS_CODE, 1, {
-              ...baseDims,
-              statusCode: '400'
-            })
-          }
-
-          // Create the custom error response
-          const errorResponse = h.response(customError).code(400)
-
-          // Ensure headers are added to the custom error response
-          if (response.output.headers) {
-            Object.entries(response.output.headers).forEach(([key, value]) =>
-              errorResponse.header(key, value)
-            )
-          }
-
-          return errorResponse
-        }
-
-        // Log HTTP status code metrics for non-400 Boom errors on receipt movement endpoints
-        if (
-          response.isBoom &&
-          response.output.statusCode !== 400 &&
-          isReceiptMovementEndpoint(request)
-        ) {
-          const endpointType = request.method.toLowerCase()
-          const statusCode = String(response.output.statusCode)
-          const clientId = request.auth?.credentials?.clientId
-
-          await metricsCounter(METRIC_NAMES.ERRORS_BY_STATUS_CODE, 1, {
-            ...withClientId({ endpointType }, clientId),
-            statusCode
-          })
-        }
-
-        // If not a validation error, continue with the default response
-        return h.continue
-      })
+      server.ext('onPreResponse', handleErrors)
     }
   }
+}
+
+export async function handleErrors(request, h) {
+  const logger = request.logger
+  const response = request.response
+
+  if (response.isBoom) {
+    logger.error({ err: response }, 'Request error')
+  }
+
+  // Check if it's a validation error (Boom error with status 400)
+  if (
+    response.isBoom &&
+    response.output.statusCode === HTTP_STATUS.BAD_REQUEST
+  ) {
+    const customError = Array.isArray(response.details)
+      ? validationErrorFormatter(response, logger)
+      : formatPayloadParseError(response)
+
+    // Log validation error metrics for receipt movement endpoints
+    if (isReceiptMovementEndpoint(request)) {
+      const endpointType = request.method.toLowerCase()
+      const clientId = request.auth?.credentials?.clientId
+      const baseDims = withClientId({ endpointType }, clientId)
+
+      await metricsCounter(
+        METRIC_NAMES.VALIDATION_ERRORS_COUNT,
+        customError.validation.errors.length,
+        baseDims
+      )
+      await metricsCounter(
+        METRIC_NAMES.VALIDATION_REQUESTS_WITH_ERRORS,
+        1,
+        baseDims
+      )
+      logger.info(
+        `${METRIC_NAMES.VALIDATION_REQUESTS_WITH_ERRORS} - ${endpointType}`
+      )
+
+      for (const error of customError.validation.errors) {
+        const errorReason = normalizeArrayIndices(error.message)
+        await metricsCounter(METRIC_NAMES.VALIDATION_ERROR_REASON, 1, {
+          ...baseDims,
+          errorReason
+        })
+        logger.info(`${METRIC_NAMES.VALIDATION_ERROR_REASON} - ${errorReason}`)
+        await metricsCounter(METRIC_NAMES.VALIDATION_ERROR_CATEGORY, 1, {
+          ...baseDims,
+          errorCategory: error.errorType
+        })
+        logger.info(
+          `${METRIC_NAMES.VALIDATION_ERROR_CATEGORY} - ${error.errorType}`
+        )
+      }
+
+      await metricsCounter(METRIC_NAMES.ERRORS_BY_STATUS_CODE, 1, {
+        ...baseDims,
+        statusCode: '400'
+      })
+      logger.info(
+        `${METRIC_NAMES.ERRORS_BY_STATUS_CODE} - ${HTTP_STATUS.BAD_REQUEST}`
+      )
+    }
+
+    // Create the custom error response
+    const errorResponse = h.response(customError).code(HTTP_STATUS.BAD_REQUEST)
+
+    // Ensure headers are added to the custom error response
+    if (response.output.headers) {
+      Object.entries(response.output.headers).forEach(([key, value]) =>
+        errorResponse.header(key, value)
+      )
+    }
+
+    return errorResponse
+  }
+
+  // Log HTTP status code metrics for non-400 Boom errors on receipt movement endpoints
+  if (
+    response.isBoom &&
+    response.output.statusCode !== HTTP_STATUS.BAD_REQUEST &&
+    isReceiptMovementEndpoint(request)
+  ) {
+    const endpointType = request.method.toLowerCase()
+    const statusCode = String(response.output.statusCode)
+    const clientId = request.auth?.credentials?.clientId
+
+    await metricsCounter(METRIC_NAMES.ERRORS_BY_STATUS_CODE, 1, {
+      ...withClientId({ endpointType }, clientId),
+      statusCode
+    })
+    logger.info(`${METRIC_NAMES.ERRORS_BY_STATUS_CODE} - ${statusCode}`)
+  }
+
+  // If not a validation error, continue with the default response
+  return h.continue
 }

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -2,6 +2,8 @@ import { createServer } from '../server.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
 import * as metrics from '../common/helpers/metrics.js'
 import { httpClients } from '../common/helpers/http-client.js'
+import { handleErrors } from './error-handler.js'
+import { HTTP_STATUS, METRIC_NAMES } from '@defra/waste-movement-utils'
 
 jest.mock('../common/helpers/metrics.js', () => ({
   metricsCounter: jest.fn(),
@@ -932,6 +934,84 @@ describe('Error Handler', () => {
         expect.any(Number),
         expect.objectContaining({ clientId: expect.anything() })
       )
+    })
+  })
+
+  describe('#handleErrors', () => {
+    let request
+
+    const h = {
+      response: jest.fn().mockReturnThis(),
+      code: jest.fn().mockReturnThis()
+    }
+
+    beforeEach(() => {
+      request = {
+        response: {
+          isBoom: true,
+          output: {},
+          details: [
+            {
+              message: '"apiCode" is required',
+              path: ['apiCode'],
+              type: 'any.required',
+              context: { label: 'apiCode', key: 'apiCode' }
+            },
+            {
+              message: '"dateTimeReceived" is required',
+              path: ['dateTimeReceived'],
+              type: 'any.required',
+              context: { label: 'dateTimeReceived', key: 'dateTimeReceived' }
+            }
+          ]
+        },
+        logger: {
+          info: jest.fn(),
+          error: jest.fn()
+        },
+        method: 'POST',
+        route: {
+          path: '/movements/receive'
+        }
+      }
+    })
+
+    it('should log errors with a 400 response code', async () => {
+      const infoLoggerSpy = jest.spyOn(request.logger, 'info')
+
+      request.response.output.statusCode = HTTP_STATUS.BAD_REQUEST
+
+      await handleErrors(request, h)
+
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.VALIDATION_REQUESTS_WITH_ERRORS} - post`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.VALIDATION_ERROR_REASON} - "apiCode" is required`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.VALIDATION_ERROR_REASON} - "dateTimeReceived" is required`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.VALIDATION_ERROR_CATEGORY} - NotProvided`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.ERRORS_BY_STATUS_CODE} - ${HTTP_STATUS.BAD_REQUEST}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledTimes(6)
+    })
+
+    it('should log errors with a non-400 response code', async () => {
+      const infoLoggerSpy = jest.spyOn(request.logger, 'info')
+
+      request.response.output.statusCode = HTTP_STATUS.INTERNAL_SERVER_ERROR
+
+      await handleErrors(request, h)
+
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.ERRORS_BY_STATUS_CODE} - ${HTTP_STATUS.INTERNAL_SERVER_ERROR}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -4,6 +4,8 @@ import { updateReceiptMovement } from './update-receipt-movement.js'
 import { createMovementRequest } from '../test/utils/createMovementRequest.js'
 import Boom from '@hapi/boom'
 import * as metrics from '../common/helpers/metrics.js'
+import * as logger from '../common/helpers/logging/logger.js'
+import { METRIC_NAMES } from '@defra/waste-movement-utils'
 
 jest.mock('../common/helpers/http-client.js', () => ({
   httpClients: {
@@ -96,6 +98,8 @@ describe('handleUpdateReceiptMovement', () => {
       statusCode: 200
     })
 
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
+
     await handleUpdateReceiptMovement(mockRequest, mockH)
 
     const { apiCode, ...payloadWithoutApiCode } = mockRequest.payload
@@ -136,6 +140,10 @@ describe('handleUpdateReceiptMovement', () => {
     )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - put`
+    )
   })
 
   it('should successfully update a receipt movement without warnings and with submittingOrganisation', async () => {
@@ -166,6 +174,8 @@ describe('handleUpdateReceiptMovement', () => {
     httpClients.wasteMovement.put.mockResolvedValueOnce({
       statusCode: 200
     })
+
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
 
     await handleUpdateReceiptMovement(completeRequest, mockH)
 
@@ -202,6 +212,10 @@ describe('handleUpdateReceiptMovement', () => {
     )
     // Developer activity metrics
     expect(metrics.logDeveloperMetrics).toHaveBeenCalledWith('test-client-id')
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - put`
+    )
   })
 
   it('should handle not found error', async () => {
@@ -267,6 +281,8 @@ describe('handleUpdateReceiptMovement', () => {
       payload: { error: 'Bad Request' }
     })
 
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
+
     await handleUpdateReceiptMovement(mockRequest, mockH)
 
     // without_errors logged with clientId-scoped dim set
@@ -281,5 +297,9 @@ describe('handleUpdateReceiptMovement', () => {
     expect(metrics.logDeveloperMetrics).not.toHaveBeenCalled()
     expect(metrics.metricsCounter).toHaveBeenCalledTimes(1)
     expect(mockH.code).toHaveBeenCalledWith(400)
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.VALIDATION_REQUESTS_WITHOUT_ERRORS} - put`
+    )
   })
 })


### PR DESCRIPTION
Ticket [DWTA-357](https://eaflood.atlassian.net/browse/DWTA-357)

This PR adds log messages where `metricsCounter()` is currently being called.

This is because `metricsCounter()` is being replaced by logging and `metricsCounter()` calls will be removed in a future commit.

This change includes moving the `errorHandler` plugin functionality to a new function `handleErrors()`, which is called by the plugin. The only changes to this part of the code are to add logging to replicate the `metricsCounter()` calls. 

Moving this functionality to a separate function makes this function much easier to unit test as it separated from the workings of the plugin. This was used to add unit tests to assert that the logger is called appropriately to log metrics.

[DWTA-357]: https://eaflood.atlassian.net/browse/DWTA-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ